### PR TITLE
Support authentication for login passkey endpoints

### DIFF
--- a/mocks/api_handler_mock.go
+++ b/mocks/api_handler_mock.go
@@ -63,6 +63,18 @@ func (mr *ApiHandlerMockMockRecorder) AuthSetHandler(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthSetHandler", reflect.TypeOf((*ApiHandlerMock)(nil).AuthSetHandler), ctx)
 }
 
+// CaptchaVerifyHandler mocks base method.
+func (m *ApiHandlerMock) CaptchaVerifyHandler(ctx *fasthttp.RequestCtx) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CaptchaVerifyHandler", ctx)
+}
+
+// CaptchaVerifyHandler indicates an expected call of CaptchaVerifyHandler.
+func (mr *ApiHandlerMockMockRecorder) CaptchaVerifyHandler(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaptchaVerifyHandler", reflect.TypeOf((*ApiHandlerMock)(nil).CaptchaVerifyHandler), ctx)
+}
+
 // FullForwardedHandler mocks base method.
 func (m *ApiHandlerMock) FullForwardedHandler(ctx *fasthttp.RequestCtx) {
 	m.ctrl.T.Helper()

--- a/router/router.go
+++ b/router/router.go
@@ -25,6 +25,8 @@ func (r *Router) register() {
 	r.ANY("/ready", r.ReadyHandler)
 
 	r.POST("/api/auth/login", r.api.AuthSetHandler)
+	r.POST("/api/auth/login/passkey", r.api.AuthSetHandler)
+	r.POST("/api/auth/login/passkey/init", r.api.CaptchaVerifyHandler)
 	r.POST("/api/auth/register", r.api.AuthSetHandler)
 	r.POST("/api/auth/provider/google", r.api.AuthSetHandler)
 	r.POST("/api/auth/logout", r.api.AuthResetHandler)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -25,8 +25,10 @@ func TestNew(t *testing.T) {
 	assert.Contains(t, l["*"], "/api/{path:*}")
 
 	assert.NotNil(t, l["POST"])
-	assert.Len(t, l["POST"], 4)
+	assert.Len(t, l["POST"], 6)
 	assert.Contains(t, l["POST"], "/api/auth/login")
+	assert.Contains(t, l["POST"], "/api/auth/login/passkey")
+	assert.Contains(t, l["POST"], "/api/auth/login/passkey/init")
 	assert.Contains(t, l["POST"], "/api/auth/logout")
 	assert.Contains(t, l["POST"], "/api/auth/register")
 	assert.Contains(t, l["POST"], "/api/auth/provider/google")


### PR DESCRIPTION
Added support of dedicated endpoints to forward auth cookies on successfull authentication.