### PR TITLE
fix(gateway): fix CSRF token race condition on HTTP/2 parallel requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 			config.Global,
 			apiService.NewHttp(retryhttp.NewFastHttpRetryClient(), config.Global),
 			captcha.NewGoogleReCaptchaProvider(retryhttp.NewFastHttpRetryClient(), config.Global),
+			csrf,
 		),
 		csrf,
 	)

--- a/mocks/csrf_handler_mock.go
+++ b/mocks/csrf_handler_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	cookie "github.com/cash-track/gateway/headers/cookie"
 	fasthttp "github.com/valyala/fasthttp"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -64,4 +65,18 @@ func (m *CsrfHandlerMock) RotateTokenHandler(ctx *fasthttp.RequestCtx) {
 func (mr *CsrfHandlerMockMockRecorder) RotateTokenHandler(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateTokenHandler", reflect.TypeOf((*CsrfHandlerMock)(nil).RotateTokenHandler), ctx)
+}
+
+// Seed mocks base method.
+func (m *CsrfHandlerMock) Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Seed", ctx, auth)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Seed indicates an expected call of Seed.
+func (mr *CsrfHandlerMockMockRecorder) Seed(ctx, auth any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seed", reflect.TypeOf((*CsrfHandlerMock)(nil).Seed), ctx, auth)
 }

--- a/router/api/handler.go
+++ b/router/api/handler.go
@@ -22,6 +22,11 @@ var allowedMethods = map[string]bool{
 	fasthttp.MethodOptions: true,
 }
 
+// CSRFSeeder seeds the CSRF token for a newly authenticated session.
+type CSRFSeeder interface {
+	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
+}
+
 type Handler interface {
 	AuthSetHandler(ctx *fasthttp.RequestCtx)
 	AuthResetHandler(ctx *fasthttp.RequestCtx)
@@ -34,13 +39,15 @@ type HttpHandler struct {
 	config  config.Config
 	captcha captcha.Provider
 	service api.Service
+	csrf    CSRFSeeder
 }
 
-func NewHttp(config config.Config, service api.Service, captcha captcha.Provider) *HttpHandler {
+func NewHttp(config config.Config, service api.Service, captcha captcha.Provider, csrf CSRFSeeder) *HttpHandler {
 	return &HttpHandler{
 		config:  config,
 		captcha: captcha,
 		service: service,
+		csrf:    csrf,
 	}
 }
 

--- a/router/api/handler_test.go
+++ b/router/api/handler_test.go
@@ -17,7 +17,7 @@ func TestAuthSetHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -39,7 +39,7 @@ func TestAuthSetHandlerCaptchaFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -56,7 +56,7 @@ func TestAuthSetHandlerCaptchaError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -73,7 +73,7 @@ func TestAuthSetHandlerLoginError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -95,7 +95,7 @@ func TestAuthResetHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -115,7 +115,7 @@ func TestFullForwardedHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -134,7 +134,7 @@ func TestFullForwardedHandlerError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -151,7 +151,7 @@ func TestFullForwardedHandlerRestrictedMethod(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodConnect)
@@ -166,7 +166,7 @@ func TestFullForwardedHandlerWithBody(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -190,7 +190,7 @@ func TestFullForwardedHandlerWithBodyError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -207,7 +207,7 @@ func TestFullForwardedHandlerWithBodyJsonError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -223,7 +223,7 @@ func TestFullForwardedHandlerWithBodyRestrictedMethod(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodConnect)
@@ -238,7 +238,7 @@ func TestHealthcheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{}, s, c)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
 
 	s.EXPECT().Healthcheck().Return(nil)
 

--- a/router/api/login.go
+++ b/router/api/login.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 
 	"github.com/valyala/fasthttp"
 
@@ -21,8 +22,13 @@ func (h *HttpHandler) Login(ctx *fasthttp.RequestCtx) error {
 
 	auth.WriteCookie(ctx)
 
-	b, _ := h.newWebAppRedirect().ToJson()
+	// Seed the initial CSRF token. Non-fatal: if Redis is unavailable the user
+	// will recover automatically on their first mutation via GET /csrf.
+	if err := h.csrf.Seed(ctx, auth); err != nil {
+		log.Printf("csrf seed failed after login: %v", err)
+	}
 
+	b, _ := h.newWebAppRedirect().ToJson()
 	ctx.Response.SetBody(b)
 
 	return nil

--- a/router/api/login_test.go
+++ b/router/api/login_test.go
@@ -12,13 +12,24 @@ import (
 	"github.com/cash-track/gateway/mocks"
 )
 
+type mockCSRFSeeder struct {
+	err    error
+	called bool
+	auth   cookie.Auth
+}
+
+func (m *mockCSRFSeeder) Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error {
+	m.called = true
+	m.auth = auth
+	return m.err
+}
+
 func TestLogin(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{
-		WebAppUrl: "https://home.com",
-	}, s, c)
+	csrf := &mockCSRFSeeder{}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Response.SetStatusCode(fasthttp.StatusOK)
@@ -30,15 +41,17 @@ func TestLogin(t *testing.T) {
 	assert.Equal(t, `{"redirectUrl":"https://home.com"}`, string(ctx.Response.Body()))
 	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
 	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), "new_refresh_token")
+	assert.True(t, csrf.called, "Seed must be called after successful login")
+	assert.Equal(t, "new_access_token", csrf.auth.AccessToken)
+	assert.Equal(t, "new_refresh_token", csrf.auth.RefreshToken)
 }
 
 func TestLoginBadStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{
-		WebAppUrl: "https://home.com",
-	}, s, c)
+	csrf := &mockCSRFSeeder{}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Response.SetStatusCode(fasthttp.StatusUnauthorized)
@@ -49,15 +62,15 @@ func TestLoginBadStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotContains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
 	assert.NotContains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), "new_refresh_token")
+	assert.False(t, csrf.called, "Seed must NOT be called on failed login")
 }
 
 func TestLoginInvalidResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
 	c := mocks.NewCaptchaProviderMock(ctrl)
-	h := NewHttp(config.Config{
-		WebAppUrl: "https://home.com",
-	}, s, c)
+	csrf := &mockCSRFSeeder{}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Response.SetStatusCode(fasthttp.StatusOK)
@@ -67,5 +80,24 @@ func TestLoginInvalidResponse(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.NotContains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
-	assert.NotContains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), "new_refresh_token")
+	assert.False(t, csrf.called, "Seed must NOT be called when response body is invalid")
+}
+
+func TestLoginSeedError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	csrf := &mockCSRFSeeder{err: assert.AnError}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Response.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+
+	// Seed failure is non-fatal: login still succeeds, user recovers via GET /csrf
+	err := h.Login(&ctx)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
+	assert.True(t, csrf.called)
 }

--- a/router/api/logout_test.go
+++ b/router/api/logout_test.go
@@ -19,7 +19,7 @@ func TestLogout(t *testing.T) {
 	c := mocks.NewCaptchaProviderMock(ctrl)
 	h := NewHttp(config.Config{
 		WebsiteUrl: "https://test.com",
-	}, s, c)
+	}, s, c, &mockCSRFSeeder{})
 
 	ctx := fasthttp.RequestCtx{}
 

--- a/router/csrf/handler.go
+++ b/router/csrf/handler.go
@@ -1,10 +1,12 @@
 package csrf
 
 import (
+	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/valyala/fasthttp"
 )
 
 type Handler interface {
 	Handler(h fasthttp.RequestHandler) fasthttp.RequestHandler
 	RotateTokenHandler(ctx *fasthttp.RequestCtx)
+	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
 }

--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -179,6 +179,31 @@ func (r *RedisHandler) RotateTokenHandler(ctx *fasthttp.RequestCtx) {
 	span.SetStatus(codes.Ok, "")
 }
 
+// Seed initialises the CSRF token for a freshly authenticated session.
+// auth must be passed directly because the access token lives in the response
+// body at login time, not in the incoming request cookies.
+func (r *RedisHandler) Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error {
+	if !auth.IsLogged() {
+		return nil
+	}
+
+	csrfCookie := cookie.CSRF{Auth: auth}
+	userCtx := newUserContext(csrfCookie)
+	if userCtx.err != nil {
+		return fmt.Errorf("csrf seed: invalid access token: %w", userCtx.err)
+	}
+
+	newToken, err := r.rotate(context.Background(), userCtx)
+	if err != nil {
+		return fmt.Errorf("csrf seed: rotate failed: %w", err)
+	}
+
+	userCtx.cookie.Token = newToken
+	userCtx.cookie.WriteCookie(ctx)
+
+	return nil
+}
+
 func (r *RedisHandler) validateCsrfRequest(ctx context.Context, userCtx userContext, method string) error {
 	if _, ok := csrfRequiredForMethods[method]; !ok {
 		return nil

--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -118,7 +118,7 @@ func (r *RedisHandler) Handler(h fasthttp.RequestHandler) fasthttp.RequestHandle
 
 		h(ctx)
 
-		if userCtx.cookie.Auth.IsLogged() {
+		if userCtx.cookie.Auth.IsLogged() && csrfRequiredForMethods[method] {
 			rotateSpanCtx, rotateSpan := traces.GetTracer().Start(
 				traces.FindParentContext(ctx),
 				fmt.Sprintf("csrf rotate %s %s", ctx.Request.Header.Method(), ctx.URI().PathOriginal()),

--- a/router/csrf/redis_handler_test.go
+++ b/router/csrf/redis_handler_test.go
@@ -20,10 +20,11 @@ func TestHandler(t *testing.T) {
 	}).SignedString([]byte("asd"))
 
 	for name, test := range map[string]struct {
-		request      *fasthttp.RequestCtx
-		setup        func(mock redismock.ClientMock)
-		expectPass   bool
-		expectStatus int
+		request             *fasthttp.RequestCtx
+		setup               func(mock redismock.ClientMock)
+		expectPass          bool
+		expectStatus        int
+		expectCsrfCookieSet bool
 	}{
 		"TokenValidForPost": {
 			request: func() *fasthttp.RequestCtx {
@@ -44,7 +45,8 @@ func TestHandler(t *testing.T) {
 					return nil
 				}).ExpectSetEx(key, nil, 0).SetVal("token_1")
 			},
-			expectPass: true,
+			expectPass:          true,
+			expectCsrfCookieSet: true,
 		},
 		"TokenInvalidForPost": {
 			request: func() *fasthttp.RequestCtx {
@@ -80,16 +82,10 @@ func TestHandler(t *testing.T) {
 				return &ctx
 			}(),
 			setup: func(mock redismock.ClientMock) {
-				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
-				mock.CustomMatch(func(expected, actual []interface{}) error {
-					assert.NotNil(t, actual)
-					if s, ok := actual[1].(string); ok {
-						assert.IsType(t, "", s)
-					}
-					return nil
-				}).ExpectSetEx(key, nil, 0).SetVal("token_1")
+				// No Redis calls expected: rotation must NOT happen for GET
 			},
-			expectPass: true,
+			expectPass:          true,
+			expectCsrfCookieSet: false,
 		},
 		"SkippedForGuest": {
 			request: func() *fasthttp.RequestCtx {
@@ -164,7 +160,12 @@ func TestHandler(t *testing.T) {
 			})(test.request)
 
 			assert.Equal(t, test.expectPass, handlersExecuted)
-			assert.NotEqual(t, string(test.request.Response.Header.PeekCookie(cookie.CsrfTokenCookieName)), "csrf_token")
+			if test.expectCsrfCookieSet {
+				assert.NotEmpty(t, test.request.Response.Header.PeekCookie(cookie.CsrfTokenCookieName))
+				assert.NotEqual(t, "csrf_token", string(test.request.Response.Header.PeekCookie(cookie.CsrfTokenCookieName)))
+			} else {
+				assert.Empty(t, test.request.Response.Header.PeekCookie(cookie.CsrfTokenCookieName))
+			}
 			if test.expectStatus > 0 {
 				assert.Equal(t, test.expectStatus, test.request.Response.StatusCode())
 			}

--- a/router/csrf/redis_handler_test.go
+++ b/router/csrf/redis_handler_test.go
@@ -357,3 +357,81 @@ func TestGetUserContextFromAccessToken(t *testing.T) {
 		})
 	}
 }
+
+func TestSeed(t *testing.T) {
+	accessToken, _ := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": 123987,
+		"iat": 987654321,
+	}).SignedString([]byte("asd"))
+
+	for name, test := range map[string]struct {
+		auth         cookie.Auth
+		setup        func(mock redismock.ClientMock)
+		expectCookie bool
+		expectError  bool
+	}{
+		"SeedsTokenForLoggedInUser": {
+			auth: cookie.Auth{
+				AccessToken:  accessToken,
+				RefreshToken: "refresh_token",
+			},
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.CustomMatch(func(expected, actual []interface{}) error {
+					assert.NotNil(t, actual)
+					if s, ok := actual[1].(string); ok {
+						assert.IsType(t, "", s)
+					}
+					return nil
+				}).ExpectSetEx(key, nil, 0).SetVal("seeded_token")
+			},
+			expectCookie: true,
+			expectError:  false,
+		},
+		"NoOpForGuest": {
+			auth:         cookie.Auth{},
+			setup:        func(mock redismock.ClientMock) {},
+			expectCookie: false,
+			expectError:  false,
+		},
+		"ErrorOnRedisFailure": {
+			auth: cookie.Auth{
+				AccessToken:  accessToken,
+				RefreshToken: "refresh_token",
+			},
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.CustomMatch(func(expected, actual []interface{}) error {
+					return nil
+				}).ExpectSetEx(key, nil, 0).SetErr(errors.New("redis down"))
+			},
+			expectCookie: false,
+			expectError:  true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client, mock := redismock.NewClientMock()
+			test.setup(mock)
+
+			ctx := fasthttp.RequestCtx{}
+			handler := NewRedisHandler(client)
+			err := handler.Seed(&ctx, test.auth)
+
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if test.expectCookie {
+				assert.NotEmpty(t, ctx.Response.Header.PeekCookie(cookie.CsrfTokenCookieName))
+			} else {
+				assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.CsrfTokenCookieName))
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause:** CSRF token was rotated in Redis after every request including GETs. Under HTTP/2 multiplexing, concurrent GET requests race to overwrite each other's tokens in Redis, leaving the browser cookie out of sync and causing the next POST/PUT to return 417.
- **Fix 1:** Gate rotation behind `csrfRequiredForMethods` — only POST/PUT/PATCH/DELETE rotate the token. GET requests now pass through without touching Redis.
- **Fix 2:** Add `Seed()` to the CSRF handler interface and call it from the login handler immediately after writing auth cookies. Previously the token was only seeded as a side-effect of GET rotation, which disappears once Fix 1 lands — without seeding at login, the first mutation after login would 417 until the user hit `GET /csrf`.

Seed failure is non-fatal: if Redis is unavailable at login time the user recovers automatically via `GET /csrf` on their next mutation.