### PR TITLE
fix(infra): add artifact-metadata:write permission to build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ permissions:
   contents: read
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   id-token: write
   attestations: write
+  artifact-metadata: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

- Adds `artifact-metadata: write` permission to `build.yml` and `release.yml` caller workflows
- Required by the shared `cash-track/.github` build workflow to attach metadata when pushing Docker image attestations