### PR TITLE
fix(gateway): seed CSRF token after JWT access token refresh

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	r := router.New(
 		apiHandler.NewHttp(
 			config.Global,
-			apiService.NewHttp(retryhttp.NewFastHttpRetryClient(), config.Global),
+			apiService.NewHttp(retryhttp.NewFastHttpRetryClient(), config.Global, csrf),
 			captcha.NewGoogleReCaptchaProvider(retryhttp.NewFastHttpRetryClient(), config.Global),
 			csrf,
 		),

--- a/router/api/handler.go
+++ b/router/api/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cash-track/gateway/captcha"
 	"github.com/cash-track/gateway/config"
 	"github.com/cash-track/gateway/headers/cookie"
+	"github.com/cash-track/gateway/router/csrf"
 	"github.com/cash-track/gateway/router/response"
 	"github.com/cash-track/gateway/service/api"
 )
@@ -20,11 +21,6 @@ var allowedMethods = map[string]bool{
 	fasthttp.MethodPatch:   true,
 	fasthttp.MethodDelete:  true,
 	fasthttp.MethodOptions: true,
-}
-
-// CSRFSeeder seeds the CSRF token for a newly authenticated session.
-type CSRFSeeder interface {
-	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
 }
 
 type Handler interface {
@@ -39,10 +35,10 @@ type HttpHandler struct {
 	config  config.Config
 	captcha captcha.Provider
 	service api.Service
-	csrf    CSRFSeeder
+	csrf    csrf.CSRFSeeder
 }
 
-func NewHttp(config config.Config, service api.Service, captcha captcha.Provider, csrf CSRFSeeder) *HttpHandler {
+func NewHttp(config config.Config, service api.Service, captcha captcha.Provider, csrf csrf.CSRFSeeder) *HttpHandler {
 	return &HttpHandler{
 		config:  config,
 		captcha: captcha,

--- a/router/csrf/handler.go
+++ b/router/csrf/handler.go
@@ -5,6 +5,11 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// CSRFSeeder seeds the CSRF token for a newly authenticated or refreshed session.
+type CSRFSeeder interface {
+	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
+}
+
 type Handler interface {
 	Handler(h fasthttp.RequestHandler) fasthttp.RequestHandler
 	RotateTokenHandler(ctx *fasthttp.RequestCtx)

--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -179,22 +179,35 @@ func (r *RedisHandler) RotateTokenHandler(ctx *fasthttp.RequestCtx) {
 	span.SetStatus(codes.Ok, "")
 }
 
-// Seed initialises the CSRF token for a freshly authenticated session.
-// auth must be passed directly because the access token lives in the response
-// body at login time, not in the incoming request cookies.
+// Seed initialises the CSRF token for a freshly authenticated or refreshed session.
+// auth must be passed directly because the access token lives in the response body,
+// not in the incoming request cookies.
 func (r *RedisHandler) Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error {
 	if !auth.IsLogged() {
 		return nil
 	}
 
+	spanCtx, span := traces.GetTracer().Start(
+		traces.FindParentContext(ctx),
+		fmt.Sprintf("csrf seed %s %s", ctx.Request.Header.Method(), ctx.URI().PathOriginal()),
+		trace.WithAttributes(traces.RequestAttributes(&ctx.Request)...),
+	)
+	defer span.End()
+
 	csrfCookie := cookie.CSRF{Auth: auth}
 	userCtx := newUserContext(csrfCookie)
 	if userCtx.err != nil {
+		span.RecordError(userCtx.err)
+		span.SetStatus(codes.Error, "invalid token")
+
 		return fmt.Errorf("csrf seed: invalid access token: %w", userCtx.err)
 	}
 
-	newToken, err := r.rotate(context.Background(), userCtx)
+	newToken, err := r.rotate(spanCtx, userCtx)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "rotate error")
+
 		return fmt.Errorf("csrf seed: rotate failed: %w", err)
 	}
 

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -134,7 +134,8 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		// Seed a fresh CSRF token keyed to the new access token's iat so the
 		// next mutating request is not rejected with 417. Non-fatal: the user
 		// can recover via GET /csrf if Redis is temporarily unavailable.
-		if s.csrf != nil {
+		// Only seed on 2xx to avoid advancing CSRF state when the retried request fails.
+		if s.csrf != nil && resp.StatusCode() >= fasthttp.StatusOK && resp.StatusCode() < fasthttp.StatusMultipleChoices {
 			if err := s.csrf.Seed(ctx, newAuth); err != nil {
 				log.Printf("[%s] csrf seed after token refresh: %s", remoteIp, err.Error())
 			}

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -130,6 +130,15 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 
 		logger.DebugResponse(resp, ServiceId)
 		retrySpan.SetAttributes(traces.ResponseAttributes(resp)...)
+
+		// Seed a fresh CSRF token keyed to the new access token's iat so the
+		// next mutating request is not rejected with 417. Non-fatal: the user
+		// can recover via GET /csrf if Redis is temporarily unavailable.
+		if s.csrf != nil {
+			if err := s.csrf.Seed(ctx, newAuth); err != nil {
+				log.Printf("[%s] csrf seed after token refresh: %s", remoteIp, err.Error())
+			}
+		}
 	}
 
 	newAuth.WriteCookie(ctx)

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -40,7 +40,7 @@ func TestFullForwardRequestWithAuth(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	uri := &fasthttp.URI{}
 	_ = uri.Parse(nil, []byte("https://gateway.test.com/api/auth/profile"))
@@ -76,7 +76,7 @@ func TestForwardRequestWithBodyOverride(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -120,7 +120,7 @@ func TestForwardRequestWithAuthRefresh(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -154,7 +154,7 @@ func TestForwardRequestWithAuthRefreshFailLogout(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -201,7 +201,7 @@ func TestForwardRequestWithAuthRefreshSecondFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -224,10 +224,130 @@ func TestForwardRequestError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.Error(t, err)
+}
+
+func TestForwardRequestWithAuthRefreshSeedsCsrf(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	// First call: original request gets 401
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	// Second call: refresh endpoint returns new tokens
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		return nil
+	})
+	// Third call: retried original request succeeds
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	csrf := mocks.NewCsrfHandlerMock(ctrl)
+	csrf.EXPECT().Seed(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.RequestCtx, auth cookie.Auth) error {
+		assert.Equal(t, "new_access_token", auth.AccessToken)
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
+}
+
+func TestForwardRequestWithAuthRefreshCsrfSeedError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		return nil
+	})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	csrf := mocks.NewCsrfHandlerMock(ctrl)
+	csrf.EXPECT().Seed(gomock.Any(), gomock.Any()).Return(fmt.Errorf("redis: connection refused"))
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	// CSRF seed failure must not propagate — ForwardRequest must succeed.
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
+}
+
+func TestForwardRequestWithAuthRefreshSecondFailNoSeed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		return nil
+	})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(fmt.Errorf("broken pipe"))
+
+	// Seed must NOT be called when the retried request itself fails.
+	csrf := mocks.NewCsrfHandlerMock(ctrl)
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
 
 	err := s.ForwardRequest(&ctx, nil)
 

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -354,6 +354,45 @@ func TestForwardRequestWithAuthRefreshSecondFailNoSeed(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestForwardRequestWithAuthRefreshNon2xxNoSeed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		return nil
+	})
+	// Retried request returns 500 — Seed must NOT be called.
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusInternalServerError)
+		return nil
+	})
+
+	csrf := mocks.NewCsrfHandlerMock(ctrl)
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+}
+
 func TestForwardResponse(t *testing.T) {
 	ctx := fasthttp.RequestCtx{}
 

--- a/service/api/healthcheck_test.go
+++ b/service/api/healthcheck_test.go
@@ -37,7 +37,7 @@ func TestHealthcheckOk(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 	err := s.Healthcheck()
 
 	assert.NoError(t, err)
@@ -58,7 +58,7 @@ func TestHealthcheckFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 	err := s.Healthcheck()
 
 	assert.Error(t, err)
@@ -75,7 +75,7 @@ func TestHealthcheckError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 	err := s.Healthcheck()
 
 	assert.Error(t, err)

--- a/service/api/refresh_token_test.go
+++ b/service/api/refresh_token_test.go
@@ -47,7 +47,7 @@ func TestRefreshTokenOk(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	auth := cookie.Auth{
 		RefreshToken: oldRefreshToken,
@@ -78,7 +78,7 @@ func TestRefreshTokenFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	auth := cookie.Auth{}
 
@@ -100,7 +100,7 @@ func TestRefreshTokenError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	auth := cookie.Auth{}
 
@@ -127,7 +127,7 @@ func TestRefreshTokenErrorBadResponse(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	auth := cookie.Auth{}
 
@@ -154,7 +154,7 @@ func TestRefreshTokenErrorLoggedOff(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	auth := cookie.Auth{}
 

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -7,8 +7,8 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/cash-track/gateway/config"
-	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/http/retryhttp"
+	"github.com/cash-track/gateway/router/csrf"
 )
 
 const (
@@ -24,11 +24,6 @@ var methodsWithBody = map[string]bool{
 	fasthttp.MethodPatch: true,
 }
 
-// CSRFSeeder seeds the CSRF token for a newly authenticated or refreshed session.
-type CSRFSeeder interface {
-	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
-}
-
 type Service interface {
 	ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) error
 	Healthcheck() error
@@ -37,10 +32,10 @@ type Service interface {
 type HttpService struct {
 	http   retryhttp.Client
 	config config.Config
-	csrf   CSRFSeeder
+	csrf   csrf.CSRFSeeder
 }
 
-func NewHttp(http retryhttp.Client, config config.Config, csrf CSRFSeeder) *HttpService {
+func NewHttp(http retryhttp.Client, config config.Config, csrf csrf.CSRFSeeder) *HttpService {
 	http.WithReadTimeout(httpReadTimeout)
 	http.WithWriteTimeout(httpWriteTimeout)
 	http.WithRetryAttempts(httpRetryAttempts)

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/valyala/fasthttp"
 
 	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/http/retryhttp"
 )
 
@@ -23,6 +24,11 @@ var methodsWithBody = map[string]bool{
 	fasthttp.MethodPatch: true,
 }
 
+// CSRFSeeder seeds the CSRF token for a newly authenticated or refreshed session.
+type CSRFSeeder interface {
+	Seed(ctx *fasthttp.RequestCtx, auth cookie.Auth) error
+}
+
 type Service interface {
 	ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) error
 	Healthcheck() error
@@ -31,9 +37,10 @@ type Service interface {
 type HttpService struct {
 	http   retryhttp.Client
 	config config.Config
+	csrf   CSRFSeeder
 }
 
-func NewHttp(http retryhttp.Client, config config.Config) *HttpService {
+func NewHttp(http retryhttp.Client, config config.Config, csrf CSRFSeeder) *HttpService {
 	http.WithReadTimeout(httpReadTimeout)
 	http.WithWriteTimeout(httpWriteTimeout)
 	http.WithRetryAttempts(httpRetryAttempts)
@@ -41,6 +48,7 @@ func NewHttp(http retryhttp.Client, config config.Config) *HttpService {
 	return &HttpService{
 		http:   http,
 		config: config,
+		csrf:   csrf,
 	}
 }
 

--- a/service/api/service_test.go
+++ b/service/api/service_test.go
@@ -19,7 +19,7 @@ func TestNewClient(t *testing.T) {
 	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 
-	s := NewHttp(h, config.Config{})
+	s := NewHttp(h, config.Config{}, nil)
 
 	assert.NotNil(t, s.http)
 }
@@ -34,7 +34,7 @@ func TestSetRequestURI(t *testing.T) {
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	uri := fasthttp.URI{}
 
@@ -53,7 +53,7 @@ func TestCopyRequestURI(t *testing.T) {
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	})
+	}, nil)
 
 	src := fasthttp.URI{}
 	src.SetPath("/api/users/create one")


### PR DESCRIPTION
## Problem

After the gateway silently refreshes an expired access token, the CSRF Redis key changes — it is keyed by `CT:csrf:{userId}:{iat}` and the new access token has a new `iat`. The next mutating request (POST/PUT/PATCH/DELETE) triggers CSRF validation, finds `redis: nil`, and the gateway returns **HTTP 417** to the client.

This was observed in production logs and reported as the \"active wallets screen error\". It affected every user session after a silent token refresh — typically the first `POST` to `/wallets/{id}/charges` after ~10 minutes of read-only browsing.

Timeline from logs:
```
2026/05/12 11:45:19  Error on validating CSRF token: error on reading token: redis: nil
```
Traefik simultaneously showed `POST /api/wallets/370/charges => 417 3ms`.

The pattern recurred 8 times in 24 hours across multiple user sessions.

## Fix

Inject a `CSRFSeeder` into `HttpService` and call `Seed()` immediately after a successful token refresh — before writing the new auth cookies to the response. This pre-populates the Redis key `CT:csrf:{userId}:{new_iat}` so the next mutating request passes validation without a 417.

The seed is non-fatal: a Redis error is logged but does not fail the forwarded request. The user retains the fallback path of `GET /csrf` if Redis is temporarily unavailable.

```
JWT access token expired
  → gateway: 401 from API
  → gateway: POST /auth/refresh → new access token
  → gateway: csrf.Seed(ctx, newAuth)   ← new
  → gateway: retry original request with new token → 200
  → gateway: write new auth cookies
```

## Changes

- `service/api/service.go` — defines `CSRFSeeder` interface; adds `csrf CSRFSeeder` field to `HttpService`; updates `NewHttp` constructor
- `service/api/forward.go` — calls `s.csrf.Seed(ctx, newAuth)` after a successful retry following token refresh
- `main.go` — passes the existing `csrf` handler to `apiService.NewHttp`
- Tests — updates all `NewHttp` call sites to pass the new parameter; adds three new tests:
  - `TestForwardRequestWithAuthRefreshSeedsCsrf` — verifies Seed is called with the new access token
  - `TestForwardRequestWithAuthRefreshCsrfSeedError` — verifies a Redis failure during seeding is non-fatal
  - `TestForwardRequestWithAuthRefreshSecondFailNoSeed` — verifies Seed is skipped when the retried request fails