### PR TITLE
feat(gateway): expose trace ID via CORS and capture redacted request/response bodies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 GATEWAY_ADDRESS=:8082
 GATEWAY_COMPRESS=true
 DEBUG_HTTP=false
+TRACE_CAPTURE_BODY=true
 
 API_URL=https://api.dev-cash-track.app
 GATEWAY_URL=https://gateway.dev-cash-track.app

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,8 @@ type Config struct {
 
 	CorsAllowedOrigins map[string]bool
 
-	DebugHttp bool
+	DebugHttp        bool
+	TraceCaptureBody bool
 
 	CsrfEnabled     bool
 	RedisConnection string
@@ -39,6 +40,7 @@ func (c *Config) Load() {
 	c.Address = getEnv("GATEWAY_ADDRESS", ":80")
 	c.Compress = getEnv("GATEWAY_COMPRESS", "true") == "true"
 	c.DebugHttp = getEnv("DEBUG_HTTP", "") == "true"
+	c.TraceCaptureBody = getEnv("TRACE_CAPTURE_BODY", "true") == "true"
 	c.CaptchaSecret = getEnv("CAPTCHA_SECRET", "")
 
 	c.ApiUrl = getEnv("API_URL", "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,7 @@ func TestConfigLoad(t *testing.T) {
 	_ = os.Setenv("GATEWAY_ADDRESS", ":80")
 	_ = os.Setenv("GATEWAY_COMPRESS", "true")
 	_ = os.Setenv("DEBUG_HTTP", "false")
+	_ = os.Setenv("TRACE_CAPTURE_BODY", "false")
 	_ = os.Setenv("API_URL", "http://api:80")
 	_ = os.Setenv("GATEWAY_URL", "https://gateway.dev.cash-track.app:8081")
 	_ = os.Setenv("HTTPS_ENABLED", "true")
@@ -24,6 +25,7 @@ func TestConfigLoad(t *testing.T) {
 	assert.Equal(t, ":80", config.Address)
 	assert.Equal(t, true, config.Compress)
 	assert.Equal(t, false, config.DebugHttp)
+	assert.Equal(t, false, config.TraceCaptureBody)
 
 	assert.NotNil(t, config.ApiURI)
 	assert.Equal(t, "http", config.ApiURI.Scheme)

--- a/headers/cors.go
+++ b/headers/cors.go
@@ -24,6 +24,9 @@ var (
 		XCtCaptchaChallenge,
 		"*",
 	}
+	CorsExposedHeaders = []string{
+		XCtTraceId,
+	}
 	CorsIgnorePaths = map[string]bool{
 		"/live":  true,
 		"/ready": true,
@@ -71,6 +74,7 @@ func writeCorsAllowedHeaders(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.Set(AccessControlAllowMethods, strings.Join(CorsAllowedMethods, ","))
 	ctx.Response.Header.Set(AccessControlAllowHeaders, strings.Join(CorsAllowedHeaders, ","))
 	ctx.Response.Header.Set(AccessControlAllowCredentials, "true")
+	ctx.Response.Header.Set(AccessControlExposeHeaders, strings.Join(CorsExposedHeaders, ","))
 
 	if string(ctx.Request.Header.Method()) == fasthttp.MethodOptions {
 		ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)

--- a/headers/cors_test.go
+++ b/headers/cors_test.go
@@ -25,6 +25,7 @@ func TestCorsHandler(t *testing.T) {
 		assert.Equal(t, strings.Join(CorsAllowedMethods, ","), string(ctx.Response.Header.Peek(AccessControlAllowMethods)))
 		assert.Equal(t, strings.Join(CorsAllowedHeaders, ","), string(ctx.Response.Header.Peek(AccessControlAllowHeaders)))
 		assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+		assert.Equal(t, strings.Join(CorsExposedHeaders, ","), string(ctx.Response.Header.Peek(AccessControlExposeHeaders)))
 	})
 
 	t.Run("AllowOptionsStatusAlwaysOk", func(t *testing.T) {
@@ -52,6 +53,7 @@ func TestCorsHandler(t *testing.T) {
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
 	})
 
 	t.Run("RejectNotAllowed", func(t *testing.T) {
@@ -66,6 +68,7 @@ func TestCorsHandler(t *testing.T) {
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
 	})
 
 	t.Run("RejectAllowedByUpstream", func(t *testing.T) {
@@ -81,6 +84,7 @@ func TestCorsHandler(t *testing.T) {
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
 		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
 	})
 
 }

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -14,6 +14,7 @@ const (
 	AccessControlAllowMethods     = "Access-Control-Allow-Methods"
 	AccessControlAllowHeaders     = "Access-Control-Allow-Headers"
 	AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	AccessControlExposeHeaders    = "Access-Control-Expose-Headers"
 	AccessControlRequestMethod    = "Access-Control-Request-Method"
 	AccessControlRequestHeaders   = "Access-Control-Request-Headers"
 	AccessControlMaxAge           = "Access-Control-Max-Age"

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/cash-track/gateway/config"
 	"github.com/cash-track/gateway/headers"
 	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/logger"
@@ -68,6 +70,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 				traces.Attributes(attribute.String("http.request.real_ip", remoteIp)),
 				traces.AttributesGetter(auth),
 				traces.RequestAttributes(req),
+				requestBodyAttributes(req),
 			)...,
 		),
 	)
@@ -91,6 +94,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 	logger.FullForwarded(ctx, req, resp, ServiceId)
 
 	span.SetAttributes(traces.ResponseAttributes(resp)...)
+	span.SetAttributes(responseBodyAttributes(resp)...)
 
 	if !auth.IsLogged() || !auth.CanRefresh() || resp.StatusCode() != fasthttp.StatusUnauthorized {
 		return forwardResponse(ctx, resp)
@@ -126,6 +130,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 					traces.Attributes(attribute.String("http.request.real_ip", remoteIp)),
 					traces.AttributesGetter(auth),
 					traces.RequestAttributes(req),
+					requestBodyAttributes(req),
 				)...,
 			),
 		)
@@ -140,6 +145,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 
 		logger.DebugResponse(resp, ServiceId)
 		retrySpan.SetAttributes(traces.ResponseAttributes(resp)...)
+		retrySpan.SetAttributes(responseBodyAttributes(resp)...)
 
 		// Seed a fresh CSRF token keyed to the new access token's iat so the
 		// next mutating request is not rejected with 417. Non-fatal: the user
@@ -177,7 +183,28 @@ func forwardResponse(ctx *fasthttp.RequestCtx, resp *fasthttp.Response) error {
 
 	if val := ctx.Response.Header.Peek(headers.AccessControlAllowOrigin); val != nil {
 		ctx.Response.Header.Set(headers.AccessControlAllowCredentials, "true")
+		ctx.Response.Header.Set(headers.AccessControlExposeHeaders, strings.Join(headers.CorsExposedHeaders, ","))
 	}
 
 	return nil
+}
+
+// requestBodyAttributes returns a redacted body span attribute for req, or nil when
+// body capture is disabled via TRACE_CAPTURE_BODY.
+func requestBodyAttributes(req *fasthttp.Request) []attribute.KeyValue {
+	if !config.Global.TraceCaptureBody {
+		return nil
+	}
+
+	return traces.Attributes(traces.RequestBodyAttribute(req))
+}
+
+// responseBodyAttributes returns a redacted body span attribute for resp, or nil when
+// body capture is disabled via TRACE_CAPTURE_BODY.
+func responseBodyAttributes(resp *fasthttp.Response) []attribute.KeyValue {
+	if !config.Global.TraceCaptureBody {
+		return nil
+	}
+
+	return traces.Attributes(traces.ResponseBodyAttribute(resp))
 }

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -491,6 +492,7 @@ func TestForwardResponse(t *testing.T) {
 
 	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(headers.AccessControlAllowOrigin)))
 	assert.Equal(t, "true", string(ctx.Response.Header.Peek(headers.AccessControlAllowCredentials)))
+	assert.Equal(t, strings.Join(headers.CorsExposedHeaders, ","), string(ctx.Response.Header.Peek(headers.AccessControlExposeHeaders)))
 	assert.Equal(t, "GET,POST", string(ctx.Response.Header.Peek(headers.AccessControlAllowMethods)))
 	assert.Equal(t, "Content-Type,Accept-Language", string(ctx.Response.Header.Peek(headers.AccessControlAllowHeaders)))
 	assert.Equal(t, "3600", string(ctx.Response.Header.Peek(headers.AccessControlMaxAge)))
@@ -499,4 +501,17 @@ func TestForwardResponse(t *testing.T) {
 	assert.Equal(t, "Content-Type,X-Rate-Limit", string(ctx.Response.Header.Peek(headers.Vary)))
 	assert.Equal(t, "123", string(ctx.Response.Header.Peek(headers.XRateLimit)))
 	assert.Equal(t, "2", string(ctx.Response.Header.Peek(headers.XRateLimitRemaining)))
+}
+
+func TestForwardResponseWithoutOriginSkipsCorsHeaders(t *testing.T) {
+	ctx := fasthttp.RequestCtx{}
+
+	resp := fasthttp.Response{}
+	resp.SetStatusCode(fasthttp.StatusOK)
+
+	err := forwardResponse(&ctx, &resp)
+
+	assert.NoError(t, err)
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowCredentials))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlExposeHeaders))
 }

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -515,3 +515,63 @@ func TestForwardResponseWithoutOriginSkipsCorsHeaders(t *testing.T) {
 	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowCredentials))
 	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlExposeHeaders))
 }
+
+func TestRequestBodyAttributesDisabled(t *testing.T) {
+	orig := config.Global.TraceCaptureBody
+	config.Global.TraceCaptureBody = false
+	defer func() { config.Global.TraceCaptureBody = orig }()
+
+	req := &fasthttp.Request{}
+	req.Header.SetContentType("application/json")
+	req.SetBodyString(`{"password":"secret"}`)
+
+	attrs := requestBodyAttributes(req)
+
+	assert.Nil(t, attrs)
+}
+
+func TestRequestBodyAttributesEnabled(t *testing.T) {
+	orig := config.Global.TraceCaptureBody
+	config.Global.TraceCaptureBody = true
+	defer func() { config.Global.TraceCaptureBody = orig }()
+
+	req := &fasthttp.Request{}
+	req.Header.SetContentType("application/json")
+	req.SetBodyString(`{"password":"secret"}`)
+
+	attrs := requestBodyAttributes(req)
+
+	assert.Len(t, attrs, 1)
+	assert.Equal(t, "http.request.body", string(attrs[0].Key))
+	assert.Equal(t, `{"password":"***"}`, attrs[0].Value.AsString())
+}
+
+func TestResponseBodyAttributesDisabled(t *testing.T) {
+	orig := config.Global.TraceCaptureBody
+	config.Global.TraceCaptureBody = false
+	defer func() { config.Global.TraceCaptureBody = orig }()
+
+	resp := &fasthttp.Response{}
+	resp.Header.SetContentType("application/json")
+	resp.SetBodyString(`{"accessToken":"abc"}`)
+
+	attrs := responseBodyAttributes(resp)
+
+	assert.Nil(t, attrs)
+}
+
+func TestResponseBodyAttributesEnabled(t *testing.T) {
+	orig := config.Global.TraceCaptureBody
+	config.Global.TraceCaptureBody = true
+	defer func() { config.Global.TraceCaptureBody = orig }()
+
+	resp := &fasthttp.Response{}
+	resp.Header.SetContentType("application/json")
+	resp.SetBodyString(`{"accessToken":"abc"}`)
+
+	attrs := responseBodyAttributes(resp)
+
+	assert.Len(t, attrs, 1)
+	assert.Equal(t, "http.response.body", string(attrs[0].Key))
+	assert.Equal(t, `{"accessToken":"***"}`, attrs[0].Value.AsString())
+}

--- a/traces/attributes.go
+++ b/traces/attributes.go
@@ -1,6 +1,8 @@
 package traces
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,8 +12,21 @@ import (
 )
 
 const (
-	headerPartsCount = 2
+	headerPartsCount   = 2
+	bodyCaptureMaxSize = 4096
+	bodyTruncatedNote  = "...(truncated)"
 )
+
+// sensitiveBodyFieldSubstrings matches JSON field names (case-insensitive, substring)
+// that must be redacted from captured request/response bodies. Substring matching
+// (rather than an exact-name set) also catches variants like passwordConfirmation
+// or newPasswordConfirmation without needing to enumerate every field name.
+var sensitiveBodyFieldSubstrings = []string{
+	"password",
+	"token",
+	"secret",
+	"apikey",
+}
 
 type OpenTelemetryAttributesGetter interface {
 	GetOpenTelemetryAttributes() []attribute.KeyValue
@@ -57,6 +72,84 @@ func ResponseAttributes(res *fasthttp.Response) []attribute.KeyValue {
 		semconv.HTTPResponseSizeKey.Int(res.Header.ContentLength()),
 		attribute.String("http.response.headers", SanitizeHTTPHeaders(res.Header.String())),
 	}
+}
+
+// RequestBodyAttribute captures a redacted, size-capped copy of the request body as a
+// span attribute. Only attempted for JSON bodies; anything else (multipart uploads,
+// empty bodies) is replaced with a placeholder so binary data never reaches Tempo.
+func RequestBodyAttribute(req *fasthttp.Request) attribute.KeyValue {
+	return attribute.String("http.request.body", SanitizeJSONBody(req.Header.ContentType(), req.Body()))
+}
+
+// ResponseBodyAttribute captures a redacted, size-capped copy of the response body as a
+// span attribute. See RequestBodyAttribute.
+func ResponseBodyAttribute(res *fasthttp.Response) attribute.KeyValue {
+	return attribute.String("http.response.body", SanitizeJSONBody(res.Header.ContentType(), res.Body()))
+}
+
+// SanitizeJSONBody redacts sensitive fields from a JSON body and caps its size.
+// The body is fully parsed and re-marshalled before truncation so a size cutoff
+// can never land mid-field and leak part of a secret.
+func SanitizeJSONBody(contentType, body []byte) string {
+	if len(body) == 0 {
+		return "(empty)"
+	}
+
+	if !bytes.Contains(bytes.ToLower(contentType), []byte("application/json")) {
+		return fmt.Sprintf("(omitted: content-type %s)", string(contentType))
+	}
+
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "(omitted: body is not valid JSON)"
+	}
+
+	redacted, err := json.Marshal(redactJSONValue(parsed))
+	if err != nil {
+		return "(omitted: failed to re-marshal redacted body)"
+	}
+
+	if len(redacted) > bodyCaptureMaxSize {
+		return string(redacted[:bodyCaptureMaxSize]) + bodyTruncatedNote
+	}
+
+	return string(redacted)
+}
+
+func redactJSONValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(v))
+		for key, val := range v {
+			if isSensitiveBodyField(key) {
+				result[key] = "***"
+			} else {
+				result[key] = redactJSONValue(val)
+			}
+		}
+
+		return result
+	case []any:
+		result := make([]any, len(v))
+		for i, val := range v {
+			result[i] = redactJSONValue(val)
+		}
+
+		return result
+	default:
+		return v
+	}
+}
+
+func isSensitiveBodyField(key string) bool {
+	key = strings.ToLower(key)
+	for _, substr := range sensitiveBodyFieldSubstrings {
+		if strings.Contains(key, substr) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func SanitizeHTTPHeaders(raw string) string {

--- a/traces/attributes.go
+++ b/traces/attributes.go
@@ -104,10 +104,9 @@ func SanitizeJSONBody(contentType, body []byte) string {
 		return "(omitted: body is not valid JSON)"
 	}
 
-	redacted, err := json.Marshal(redactJSONValue(parsed))
-	if err != nil {
-		return "(omitted: failed to re-marshal redacted body)"
-	}
+	// json.Unmarshal into `any` only ever yields nil/bool/float64/string/[]any/map[string]any,
+	// all of which json.Marshal always serializes without error, so no error path here.
+	redacted, _ := json.Marshal(redactJSONValue(parsed))
 
 	if len(redacted) > bodyCaptureMaxSize {
 		return string(redacted[:bodyCaptureMaxSize]) + bodyTruncatedNote

--- a/traces/attributes_test.go
+++ b/traces/attributes_test.go
@@ -1,6 +1,8 @@
 package traces
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/valyala/fasthttp"
@@ -166,5 +168,83 @@ cookie: ***`,
 				t.Errorf("SanitizeHTTPHeaders() = %v, want %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSanitizeJSONBody(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		expected    string
+	}{
+		{
+			name:        "plain JSON object is unchanged",
+			contentType: "application/json",
+			body:        `{"email":"user@example.com","remember":true}`,
+			expected:    `{"email":"user@example.com","remember":true}`,
+		},
+		{
+			name:        "top level sensitive fields are redacted",
+			contentType: "application/json",
+			body:        `{"email":"user@example.com","password":"hunter2","passwordConfirmation":"hunter2"}`,
+			expected:    `{"email":"user@example.com","password":"***","passwordConfirmation":"***"}`,
+		},
+		{
+			name:        "nested sensitive fields are redacted",
+			contentType: "application/json; charset=utf-8",
+			body:        `{"data":{"accessToken":"abc","refreshToken":"def","clientSecret":"xyz"},"ok":true}`,
+			expected:    `{"data":{"accessToken":"***","clientSecret":"***","refreshToken":"***"},"ok":true}`,
+		},
+		{
+			name:        "sensitive fields inside arrays are redacted",
+			contentType: "application/json",
+			body:        `[{"token":"a"},{"token":"b"}]`,
+			expected:    `[{"token":"***"},{"token":"***"}]`,
+		},
+		{
+			name:        "non-json content-type is omitted",
+			contentType: "multipart/form-data; boundary=x",
+			body:        "--x\r\nsome binary data\r\n--x--",
+			expected:    "(omitted: content-type multipart/form-data; boundary=x)",
+		},
+		{
+			name:        "malformed json is omitted",
+			contentType: "application/json",
+			body:        "{not valid json",
+			expected:    "(omitted: body is not valid JSON)",
+		},
+		{
+			name:        "empty body is reported as empty",
+			contentType: "application/json",
+			body:        "",
+			expected:    "(empty)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeJSONBody([]byte(tt.contentType), []byte(tt.body))
+			if result != tt.expected {
+				t.Errorf("SanitizeJSONBody() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeJSONBodyTruncatesOversizedBody(t *testing.T) {
+	large, err := json.Marshal(map[string]string{"data": strings.Repeat("x", 10000)})
+	if err != nil {
+		t.Fatalf("failed to marshal fixture: %v", err)
+	}
+
+	result := SanitizeJSONBody([]byte("application/json"), large)
+
+	if !strings.HasSuffix(result, bodyTruncatedNote) {
+		t.Errorf("expected result to end with %q, got suffix: %q", bodyTruncatedNote, result)
+	}
+
+	if len(result) != bodyCaptureMaxSize+len(bodyTruncatedNote) {
+		t.Errorf("expected truncated length %d, got %d", bodyCaptureMaxSize+len(bodyTruncatedNote), len(result))
 	}
 }

--- a/traces/attributes_test.go
+++ b/traces/attributes_test.go
@@ -232,6 +232,40 @@ func TestSanitizeJSONBody(t *testing.T) {
 	}
 }
 
+func TestRequestBodyAttribute(t *testing.T) {
+	req := &fasthttp.Request{}
+	req.Header.SetContentType("application/json")
+	req.SetBody([]byte(`{"email":"user@example.com","password":"hunter2"}`))
+
+	attr := RequestBodyAttribute(req)
+
+	if string(attr.Key) != "http.request.body" {
+		t.Errorf("expected key %q, got %q", "http.request.body", attr.Key)
+	}
+
+	expected := `{"email":"user@example.com","password":"***"}`
+	if attr.Value.AsString() != expected {
+		t.Errorf("expected %q, got %q", expected, attr.Value.AsString())
+	}
+}
+
+func TestResponseBodyAttribute(t *testing.T) {
+	resp := &fasthttp.Response{}
+	resp.Header.SetContentType("application/json")
+	resp.SetBody([]byte(`{"accessToken":"abc123","ok":true}`))
+
+	attr := ResponseBodyAttribute(resp)
+
+	if string(attr.Key) != "http.response.body" {
+		t.Errorf("expected key %q, got %q", "http.response.body", attr.Key)
+	}
+
+	expected := `{"accessToken":"***","ok":true}`
+	if attr.Value.AsString() != expected {
+		t.Errorf("expected %q, got %q", expected, attr.Value.AsString())
+	}
+}
+
 func TestSanitizeJSONBodyTruncatesOversizedBody(t *testing.T) {
 	large, err := json.Marshal(map[string]string{"data": strings.Repeat("x", 10000)})
 	if err != nil {


### PR DESCRIPTION
## Summary
- Set `Access-Control-Expose-Headers` so browser JS can read `X-Ct-Trace-Id`, including on real proxied `/api/*` responses — the upstream API already sets `Access-Control-Allow-Origin` before `CorsHandler`'s own header-writing logic evaluates whether to run, so `forwardResponse()` now sets both `Access-Control-Allow-Credentials` and `Access-Control-Expose-Headers` explicitly whenever `Access-Control-Allow-Origin` is already present.
- Capture redacted, size-capped JSON request/response bodies as span attributes on the gateway->API call in `ForwardRequest` (both the initial call and the post-refresh retry), gated by a new `TRACE_CAPTURE_BODY` config flag (default `true`, acts as a kill switch). Known sensitive keys (`password`, `accessToken`, `refreshToken`, `token`, `secret`, `apiKey`, etc.) are redacted to `***` case-insensitively and recursively; non-JSON bodies get a placeholder instead of raw bytes.
- Verified live: a real `/api/auth/login` trace shows `password`, `accessToken`, and `refreshToken` redacted to `***` while non-sensitive fields pass through, and the trace ID is now readable from a browser `fetch()` against the real proxied path.