### PR TITLE
docs(gateway): correct the documented origins of HTTP 500

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -163,6 +163,18 @@ paths:
               $ref: "#/components/headers/GatewaySha"
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          description: |
+            The gateway could not issue a new token (Redis unreachable or write failure).
+            The response has no body. The previous `cshtrkcsrf` cookie is left untouched, so
+            retrying is safe.
+          headers:
+            X-Ct-Trace-Id:
+              $ref: "#/components/headers/TraceId"
+            X-Ct-Gateway-Version:
+              $ref: "#/components/headers/GatewayVersion"
+            X-Ct-Gateway-Sha:
+              $ref: "#/components/headers/GatewaySha"
 
   # ===========================================================================
   # AUTH — gateway-handled flows
@@ -618,13 +630,27 @@ paths:
       summary: CORS preflight
       description: |
         Handles CORS preflight requests. CSRF validation is bypassed for OPTIONS.
-        The gateway responds with the appropriate `Access-Control-*` headers based on
-        the `CORS_ALLOWED_ORIGINS` configuration.
+
+        The gateway does **not** answer the preflight by itself: `OPTIONS` is an allowed proxy
+        method, so the request is forwarded to the backend API first and the backend's response
+        is what the client receives. The CORS layer then runs afterwards and, **only if the
+        `Origin` is in `CORS_ALLOWED_ORIGINS`**, adds the `Access-Control-*` headers and
+        overwrites the status with `200` — whatever the backend actually returned.
+
+        The practical consequences:
+
+        - Allowed origin → always `200`, regardless of the backend's status. The backend's
+          response headers (including `X-Ct-Api-Version` / `X-Ct-Api-Sha`) are still relayed.
+        - Disallowed or missing origin → no `Access-Control-*` headers and no status override,
+          so the backend's status and body pass through unchanged.
+        - Backend unreachable → `502`, before the CORS layer has anything to overwrite.
       tags: [Proxy]
       security: []
       responses:
         "200":
-          description: Preflight accepted
+          description: |
+            Preflight accepted. Note this status is imposed by the CORS layer for an allowed
+            origin and does not imply the backend returned `200`.
           headers:
             Access-Control-Allow-Origin:
               schema:
@@ -645,6 +671,12 @@ paths:
               $ref: "#/components/headers/GatewayVersion"
             X-Ct-Gateway-Sha:
               $ref: "#/components/headers/GatewaySha"
+            X-Ct-Api-Version:
+              $ref: "#/components/headers/ApiVersion"
+            X-Ct-Api-Sha:
+              $ref: "#/components/headers/ApiSha"
+        "502":
+          $ref: "#/components/responses/BadGateway"
 
 # =============================================================================
 # COMPONENTS
@@ -992,13 +1024,47 @@ components:
 
     InternalError:
       description: |
-        Gateway internal error — either an unexpected captcha service response or a gateway-side
-        failure before the request was forwarded.
+        HTTP 500. Three distinct origins share this status. Use the `X-Ct-Api-*` headers to
+        tell them apart: they are set by the backend and only ever relayed by the gateway, so
+        their presence means the request reached the API.
+
+        1. **Relayed from the backend API.** The gateway forwards the upstream status, body and
+           headers verbatim, exactly as it does for `400`/`403`/`404`/`422`/`429`. On the proxy
+           routes this is the common case. `X-Ct-Api-Version` / `X-Ct-Api-Sha` are **present**
+           (unless the backend image predates them).
+        2. **Captcha service failure**, on the captcha-gated auth routes only. The gateway could
+           not get a usable answer from reCAPTCHA and rejected the request before forwarding.
+           No `X-Ct-Api-*` headers.
+        3. **CSRF token rotation failure**, on authenticated `POST`/`PUT`/`PATCH`/`DELETE`.
+           Rotation runs *after* the backend has already replied, so the gateway overwrites the
+           status with `500` while leaving the backend's body and headers in place. The body
+           will therefore look like a success payload and `X-Ct-Api-*` headers **are** present.
+           The request itself was applied by the backend — only the new CSRF token was lost, and
+           the client recovers with `GET /csrf`.
+
+        A gateway failure to *reach* the backend is reported as `502` (see `BadGateway`), never
+        as `500`.
       headers:
+        X-Ct-Trace-Id:
+          $ref: "#/components/headers/TraceId"
         X-Ct-Gateway-Version:
           $ref: "#/components/headers/GatewayVersion"
         X-Ct-Gateway-Sha:
           $ref: "#/components/headers/GatewaySha"
+        X-Ct-Api-Version:
+          description: |
+            Present when the response originated from the backend (origins 1 and 3 above),
+            absent on a captcha failure (origin 2). See `#/components/headers/ApiVersion`.
+          schema:
+            type: string
+            example: "v3.1.0"
+        X-Ct-Api-Sha:
+          description: |
+            Present when the response originated from the backend (origins 1 and 3 above),
+            absent on a captcha failure (origin 2). See `#/components/headers/ApiSha`.
+          schema:
+            type: string
+            example: "9f8e7d6c5b4a"
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Problem

`InternalError` described every `500` as "a gateway-side failure before the request was forwarded". On the proxy routes that is the *least* likely origin, and there turned out to be three, not one.

Closes #45.

Builds on #46 (now merged), which is what makes the `X-Ct-Api-*` headers available as the discriminator between the cases below.

## Changes

Spec-only — no behaviour is modified.

### `InternalError` now documents all three origins

| # | Origin | Where | `X-Ct-Api-*` |
|---|---|---|---|
| 1 | **Relayed backend 500** | any forwarded route | present |
| 2 | Captcha service failure | captcha-gated auth routes | absent |
| 3 | **CSRF rotation failure** | authenticated `POST`/`PUT`/`PATCH`/`DELETE` | present |

Origin 1 is the one the issue was filed about: `forwardResponse` copies the upstream status verbatim (`ctx.SetStatusCode(resp.StatusCode())`), so a backend `500` travels the identical path to `400`/`403`/`404`/`422`/`429` — all of which the spec already maps to `Backend*` components. Only `500` was singled out and attributed to the gateway.

Origin 3 was found while verifying the above and is the nastiest of the three. `RedisHandler.Handler` rotates the CSRF token *after* `h(ctx)` has already run, and on failure does `ctx.SetStatusCode(500)` — overwriting the status while leaving the backend's body and headers in place. The client sees a `500` carrying what looks like a success payload, and **the mutation was actually applied by the backend**; only the new CSRF token was lost. Recovery is `GET /csrf`. That was not documented anywhere.

The `X-Ct-Api-Version` / `X-Ct-Api-Sha` headers from #46 are what distinguishes the cases, since the gateway only ever relays them from upstream and never synthesizes them. They are now listed on `InternalError` with per-case notes, instead of being omitted as though a `500` could never originate from the backend. `X-Ct-Trace-Id` was also missing and is added.

### Two related gaps found while verifying

- **`GET /csrf` could return an undocumented `500`.** `RotateTokenHandler` returns a bodiless `500` when the Redis `SetEx` in `rotate` fails. It returns *before* `WriteCookie`, so the existing `cshtrkcsrf` cookie is left untouched and retrying is safe — now stated in the spec.
- **`OPTIONS` was modelled as if the gateway answered preflight itself.** It does not. `OPTIONS` is in `allowedMethods`, so the request is forwarded to the backend, and `CorsHandler` only runs afterwards — overwriting the status to `200` *only* when the `Origin` is in `CORS_ALLOWED_ORIGINS`. So: allowed origin → always `200` regardless of what the backend said, with the backend's headers still relayed; disallowed origin → the backend's status and body pass straight through; unreachable backend → `502`. Documented, and the `502` response and the relayed `X-Ct-Api-*` headers added.

## Verification

- `redocly lint openapi.yaml` — **valid**, 3 warnings, the same pre-existing set as the base branch (`/live`, `/ready`, `OPTIONS` each lacking a `4xx` response).
- Spec parsed and asserted structurally: `InternalError` carries all five headers, `/csrf` exposes `200/401/500`, `OPTIONS` exposes `200/502` with the API headers on the `200`.
- Every claim traced to code rather than inferred: the three `500` sites (`response/captcha.go:13`, `csrf/redis_handler.go:135`, `csrf/redis_handler.go:171`), `forwardResponse`'s verbatim status relay, `rotate`'s single Redis failure mode, `writeCorsAllowedHeaders`' status override, and `allowedMethods` including `OPTIONS`.
- `git diff --name-only` confirms `docs/openapi.yaml` is the only file touched.

### Left alone

The `OPTIONS` `operation-4xx-response` lint warning stays. A disallowed origin passes the backend's status through, so the honest set of 4xx codes is "whatever the backend returns" — inventing one to silence the warning would trade a visible warning for an invented fact.
