### PR TITLE
fix(gateway): trust client IP headers only from configured proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ WEBAPP_URL=https://my.dev-cash-track.app
 WEBSITE_URL=https://dev-cash-track.app
 CORS_ALLOWED_ORIGINS=https://dev-cash-track.app,https://my.dev-cash-track.app
 
+# Comma-separated CIDRs/IPs trusted to set Cf-Connecting-IP. Empty = default (RFC1918 + loopback):
+# trusts every container on the Compose network, not just Traefik. Pin this to Traefik's own address for a hardened deployment.
+TRUSTED_PROXIES=
+
 CAPTCHA_SECRET=
 
 HTTPS_ENABLED=false

--- a/config/config.go
+++ b/config/config.go
@@ -2,10 +2,15 @@ package config
 
 import (
 	"fmt"
+	"log"
+	"net/netip"
 	"net/url"
 	"os"
 	"strings"
 )
+
+// RFC1918 + loopback: covers Traefik on a Docker bridge network out of the box.
+const defaultTrustedProxies = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,127.0.0.0/8,::1/128"
 
 type Config struct {
 	Address       string
@@ -26,6 +31,9 @@ type Config struct {
 	CookieSecure bool
 
 	CorsAllowedOrigins map[string]bool
+
+	// Peers allowed to set Cf-Connecting-IP (e.g. Traefik).
+	TrustedProxies []netip.Prefix
 
 	DebugHttp        bool
 	TraceCaptureBody bool
@@ -65,6 +73,7 @@ func (c *Config) Load() {
 	c.CookieSecure = getCookieSecure(c.GatewayUrl)
 
 	c.CorsAllowedOrigins = getCorsAllowedOrigins(getEnv("CORS_ALLOWED_ORIGINS", ""))
+	c.TrustedProxies = getTrustedProxies(getEnv("TRUSTED_PROXIES", defaultTrustedProxies))
 
 	c.CsrfEnabled = getEnv("CSRF_ENABLED", "") == "true"
 	c.RedisConnection = getEnv("REDIS_CONNECTION", "localhost:6379")
@@ -109,4 +118,41 @@ func getCorsAllowedOrigins(val string) map[string]bool {
 	}
 
 	return list
+}
+
+// getTrustedProxies parses a comma-separated list of CIDRs and/or bare IPs.
+// Bare IPs are normalised to a /32 or /128 prefix. Invalid entries are logged and skipped.
+func getTrustedProxies(val string) []netip.Prefix {
+	list := make([]netip.Prefix, 0)
+
+	for _, v := range strings.Split(val, ",") {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+
+		prefix, err := parseTrustedProxy(v)
+		if err != nil {
+			log.Printf("Skipping invalid TRUSTED_PROXIES entry %q: %s", v, err)
+
+			continue
+		}
+
+		list = append(list, prefix)
+	}
+
+	return list
+}
+
+func parseTrustedProxy(v string) (netip.Prefix, error) {
+	if prefix, err := netip.ParsePrefix(v); err == nil {
+		return prefix, nil
+	}
+
+	addr, err := netip.ParseAddr(v)
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("not a valid CIDR or IP: %w", err)
+	}
+
+	return netip.PrefixFrom(addr, addr.BitLen()), nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/netip"
 	"os"
 	"testing"
 
@@ -20,6 +21,7 @@ func TestConfigLoad(t *testing.T) {
 	_ = os.Setenv("REDIS_CONNECTION", "redis:1234")
 	_ = os.Setenv("GIT_TAG", "v1.2.3")
 	_ = os.Setenv("GIT_COMMIT", "abc123def456")
+	t.Setenv("TRUSTED_PROXIES", "")
 
 	config := &Config{}
 	config.Load()
@@ -49,6 +51,14 @@ func TestConfigLoad(t *testing.T) {
 	_, ok = config.CorsAllowedOrigins["https://dev.cash-track.app:3000"]
 	assert.Equal(t, true, ok)
 
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("::1/128"),
+	}, config.TrustedProxies)
+
 	assert.Equal(t, true, config.CsrfEnabled)
 	assert.Equal(t, "redis:1234", config.RedisConnection)
 
@@ -77,4 +87,48 @@ func TestConfigLoadUnexpectedApiUrl(t *testing.T) {
 	assert.Panics(t, func() {
 		config.Load()
 	})
+}
+
+func TestConfigLoadTrustedProxiesCustom(t *testing.T) {
+	_ = os.Setenv("API_URL", "http://api:80")
+	t.Setenv("TRUSTED_PROXIES", "10.10.0.0/16,,172.20.0.5, not-a-cidr, ::1,")
+
+	config := &Config{}
+
+	assert.NotPanics(t, func() {
+		config.Load()
+	})
+
+	// bare IPs are normalised to /32 or /128, and the invalid entry is skipped, not fatal.
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("10.10.0.0/16"),
+		netip.MustParsePrefix("172.20.0.5/32"),
+		netip.MustParsePrefix("::1/128"),
+	}, config.TrustedProxies)
+}
+
+func TestConfigLoadTrustedProxiesEmptyUsesDefault(t *testing.T) {
+	_ = os.Setenv("API_URL", "http://api:80")
+	t.Setenv("TRUSTED_PROXIES", "")
+
+	config := &Config{}
+	config.Load()
+
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("10.0.0.0/8"),
+		netip.MustParsePrefix("172.16.0.0/12"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("127.0.0.0/8"),
+		netip.MustParsePrefix("::1/128"),
+	}, config.TrustedProxies)
+}
+
+func TestConfigLoadTrustedProxiesAllInvalidYieldsEmptyList(t *testing.T) {
+	_ = os.Setenv("API_URL", "http://api:80")
+	t.Setenv("TRUSTED_PROXIES", "garbage, also-garbage")
+
+	config := &Config{}
+	config.Load()
+
+	assert.Empty(t, config.TrustedProxies)
 }

--- a/headers/clientip.go
+++ b/headers/clientip.go
@@ -1,9 +1,18 @@
 package headers
 
-import "github.com/valyala/fasthttp"
+import (
+	"net/netip"
+	"strings"
+
+	"github.com/valyala/fasthttp"
+
+	"github.com/cash-track/gateway/config"
+)
 
 var clientIpUserValue = []byte("ClientIP")
-var ipHeaders = []string{CfConnectingIP, XRealIp, XForwardedFor}
+
+// Only Cf-Connecting-IP: it's the only header here Cloudflare always sets and overwrites itself.
+var ipHeaders = []string{CfConnectingIP}
 
 func GetClientIPFromContext(ctx *fasthttp.RequestCtx) string {
 	if v, ok := ctx.UserValueBytes(clientIpUserValue).(string); ok {
@@ -13,16 +22,44 @@ func GetClientIPFromContext(ctx *fasthttp.RequestCtx) string {
 	return ctx.RemoteIP().String()
 }
 
+// findRealClientIP trusts the IP headers only when the direct peer is a configured trusted proxy.
 func findRealClientIP(ctx *fasthttp.RequestCtx) string {
-	for _, h := range ipHeaders {
-		if val := ctx.Request.Header.PeekAll(h); len(val) > 0 {
-			for _, v := range val {
-				if string(v) != "" {
-					return string(v)
+	if isTrustedPeer(ctx) {
+		for _, h := range ipHeaders {
+			for _, line := range ctx.Request.Header.PeekAll(h) {
+				if addr, ok := parseClientIP(line); ok {
+					return addr.String()
 				}
 			}
 		}
 	}
 
 	return ctx.RemoteIP().String()
+}
+
+// parseClientIP trims and validates a header value as a bare IP; zone-scoped addresses (fe80::1%eth0) are rejected.
+func parseClientIP(raw []byte) (netip.Addr, bool) {
+	addr, err := netip.ParseAddr(strings.TrimSpace(string(raw)))
+	if err != nil || addr.Zone() != "" {
+		return netip.Addr{}, false
+	}
+
+	return addr, true
+}
+
+// isTrustedPeer reports whether the direct connection peer is a configured trusted proxy.
+func isTrustedPeer(ctx *fasthttp.RequestCtx) bool {
+	peer, ok := netip.AddrFromSlice(ctx.RemoteIP())
+
+	return ok && isTrustedProxy(peer.Unmap())
+}
+
+func isTrustedProxy(addr netip.Addr) bool {
+	for _, prefix := range config.Global.TrustedProxies {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/headers/clientip_test.go
+++ b/headers/clientip_test.go
@@ -1,10 +1,14 @@
 package headers
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
+
+	"github.com/cash-track/gateway/config"
 )
 
 func TestGetClientIPFromContext(t *testing.T) {
@@ -20,41 +24,121 @@ func TestGetClientIPFromContext(t *testing.T) {
 }
 
 func TestFindRealClientIP(t *testing.T) {
+	trustedProxies := []netip.Prefix{
+		netip.MustParsePrefix("192.168.1.0/24"),
+		netip.MustParsePrefix("::1/128"),
+	}
 
 	for name, test := range map[string]struct {
-		Headers    map[string]string
-		ExpectedIP string
+		RemoteAddr     string
+		TrustedProxies []netip.Prefix
+		Headers        map[string]string
+		ExpectedIP     string
 	}{
-		"CloudFlare": {
-			ExpectedIP: "192.168.1.2",
+		"TrustedPeerCloudFlareHeaderWins": {
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
 			Headers: map[string]string{
-				CfConnectingIP: "192.168.1.2",
-				XRealIp:        "192.168.1.1",
-				XForwardedFor:  "192.168.1.0",
+				CfConnectingIP: "203.0.113.5",
+				XRealIp:        "203.0.113.6",
+				XForwardedFor:  "203.0.113.7",
 			},
+			ExpectedIP: "203.0.113.5",
 		},
-		"Real": {
-			ExpectedIP: "192.168.1.1",
+		"UntrustedPeerSpoofedCloudFlareHeaderIgnored": {
+			RemoteAddr:     "10.0.0.5",
+			TrustedProxies: trustedProxies,
+			Headers: map[string]string{
+				CfConnectingIP: "203.0.113.5",
+			},
+			ExpectedIP: "10.0.0.5",
+		},
+		"TrustedPeerXRealIPAloneIsIgnoredFallsBackToRemoteIP": {
+			// X-Real-IP has no authoritative writer here: never trusted, even from a trusted peer.
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
 			Headers: map[string]string{
 				CfConnectingIP: "",
-				XRealIp:        "192.168.1.1",
-				XForwardedFor:  "192.168.1.0",
+				XRealIp:        "203.0.113.6",
+				XForwardedFor:  "203.0.113.7",
 			},
+			ExpectedIP: "192.168.1.10",
 		},
-		"Forwarded": {
-			ExpectedIP: "192.168.1.0",
+		"TrustedPeerForwardedForAloneIsIgnoredFallsBackToRemoteIP": {
+			// X-Forwarded-For alone is never enough: it's not in ipHeaders at all.
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
 			Headers: map[string]string{
 				CfConnectingIP: "",
-				XForwardedFor:  "192.168.1.0",
+				XForwardedFor:  "203.0.113.7",
 			},
+			ExpectedIP: "192.168.1.10",
 		},
-		"RemoteAddress": {
+		"TrustedPeerForwardedForAppendChainNeverYieldsAttackerEntry": {
+			// Real chain shape is <attacker>, <real client>, <cf edge> — must not return "6.6.6.6".
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
+			Headers: map[string]string{
+				XForwardedFor: "6.6.6.6, 203.0.113.9, 172.71.1.1",
+			},
+			ExpectedIP: "192.168.1.10",
+		},
+		"TrustedPeerMalformedCloudFlareFallsThroughToRemoteIP": {
+			// A malformed Cf-Connecting-IP falls straight to RemoteIP; other headers are noise, not a fallback.
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
+			Headers: map[string]string{
+				CfConnectingIP: "not-an-ip",
+				XRealIp:        "203.0.113.6",
+				XForwardedFor:  "still, not, an, ip",
+			},
+			ExpectedIP: "192.168.1.10",
+		},
+		"TrustedPeerZoneScopedIPv6HeaderRejectedFallsBackToRemoteIP": {
+			// A zone identifier is never meaningful for a public client IP; must not leak into the result.
+			RemoteAddr:     "::1",
+			TrustedProxies: trustedProxies,
+			Headers: map[string]string{
+				CfConnectingIP: "fe80::1%eth0",
+			},
+			ExpectedIP: "::1",
+		},
+		"TrustedIPv6PeerIPv6HeaderValue": {
+			RemoteAddr:     "::1",
+			TrustedProxies: trustedProxies,
+			Headers: map[string]string{
+				CfConnectingIP: "2001:db8::1",
+			},
+			ExpectedIP: "2001:db8::1",
+		},
+		"TrustedPeerEmptyHeadersFallsThroughToRemoteIP": {
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: trustedProxies,
+			Headers:        map[string]string{},
+			ExpectedIP:     "192.168.1.10",
+		},
+		"NoTrustedProxiesConfiguredHeaderIgnored": {
+			RemoteAddr:     "192.168.1.10",
+			TrustedProxies: nil,
+			Headers: map[string]string{
+				CfConnectingIP: "203.0.113.5",
+			},
+			ExpectedIP: "192.168.1.10",
+		},
+		"DefaultUnsetRemoteAddrNoHeaders": {
+			// RemoteAddr left empty: skip SetRemoteAddr, exercising fasthttp's own zero value.
 			ExpectedIP: "0.0.0.0",
-			Headers:    map[string]string{},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			original := config.Global.TrustedProxies
+			config.Global.TrustedProxies = test.TrustedProxies
+			defer func() { config.Global.TrustedProxies = original }()
+
 			ctx := fasthttp.RequestCtx{}
+			if test.RemoteAddr != "" {
+				ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP(test.RemoteAddr)})
+			}
 
 			for key, value := range test.Headers {
 				ctx.Request.Header.Set(key, value)
@@ -64,5 +148,4 @@ func TestFindRealClientIP(t *testing.T) {
 			assert.Equal(t, test.ExpectedIP, clientIp)
 		})
 	}
-
 }

--- a/headers/cloudflare.go
+++ b/headers/cloudflare.go
@@ -12,14 +12,26 @@ const (
 	CloudFlareInternalHeaderPrefix = "Cf-Original-"
 )
 
-// CopyCloudFlareHeaders keep original CloudFlare incoming headers for other services behind gateway.
+// CopyCloudFlareHeaders keeps original CloudFlare incoming headers for other services behind gateway.
+// Only copies from a trusted peer — otherwise Cf-* is attacker input, not real CloudFlare data.
 func CopyCloudFlareHeaders(ctx *fasthttp.RequestCtx, req *fasthttp.Request) {
+	if !isTrustedPeer(ctx) {
+		return
+	}
+
 	for _, key := range ctx.Request.Header.PeekKeys() {
 		if !strings.HasPrefix(string(key), CloudFlareIncomingHeaderPrefix) {
 			continue
 		}
 
 		if val := ctx.Request.Header.PeekBytes(key); val != nil {
+			// Cf-Connecting-IP keys the upstream rate limiter's bucket: drop it here rather than forward garbage.
+			if strings.EqualFold(string(key), CfConnectingIP) {
+				if _, ok := parseClientIP(val); !ok {
+					continue
+				}
+			}
+
 			req.Header.SetBytesV(
 				CloudFlareInternalHeaderPrefix+strings.TrimPrefix(string(key), CloudFlareIncomingHeaderPrefix),
 				bytes.Clone(val),

--- a/headers/cloudflare_test.go
+++ b/headers/cloudflare_test.go
@@ -1,15 +1,24 @@
 package headers
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
+
+	"github.com/cash-track/gateway/config"
 )
 
 func TestCopyCloudFlareHeaders(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
 	ctx := fasthttp.RequestCtx{}
 	req := fasthttp.Request{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("192.168.1.10")})
 
 	ctx.Request.Header.SetBytesV("Cf-Connection-Ip", []byte("192.168.1.1, 10.0.0.1"))
 	ctx.Request.Header.SetBytesV("X-Request-Id", []byte("123456"))
@@ -21,4 +30,86 @@ func TestCopyCloudFlareHeaders(t *testing.T) {
 	assert.Empty(t, req.Header.Peek("Cf-Connection-Ip"))
 	assert.Empty(t, req.Header.Peek("X-Request-Id"))
 	assert.Empty(t, req.Header.Peek("CfIndex"))
+}
+
+func TestCopyCloudFlareHeadersValidConnectingIPCopied(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
+	ctx := fasthttp.RequestCtx{}
+	req := fasthttp.Request{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("192.168.1.10")})
+
+	ctx.Request.Header.SetBytesV(CfConnectingIP, []byte("203.0.113.5"))
+	ctx.Request.Header.SetBytesV("Cf-Index", []byte("qwerty"))
+
+	CopyCloudFlareHeaders(&ctx, &req)
+
+	assert.Equal(t, "203.0.113.5", string(req.Header.Peek("Cf-Original-Connecting-Ip")))
+	assert.Equal(t, "qwerty", string(req.Header.Peek("Cf-Original-Index")))
+}
+
+func TestCopyCloudFlareHeadersMalformedConnectingIPNotCopiedOthersAre(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
+	for name, malformed := range map[string]string{
+		"NotAnIP":      "not-an-ip",
+		"CIDR":         "1.2.3.4/24",
+		"WithPort":     "1.2.3.4:80",
+		"ObsFolded":    "1.2.3.4\r\n ,9.9.9.9",
+		"EmbeddedNull": "1.2.3\x004.5",
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := fasthttp.RequestCtx{}
+			req := fasthttp.Request{}
+			ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("192.168.1.10")})
+
+			ctx.Request.Header.SetBytesV(CfConnectingIP, []byte(malformed))
+			ctx.Request.Header.SetBytesV("Cf-Ray", []byte("abc123"))
+
+			CopyCloudFlareHeaders(&ctx, &req)
+
+			assert.Empty(t, req.Header.Peek("Cf-Original-Connecting-Ip"))
+			assert.Equal(t, "abc123", string(req.Header.Peek("Cf-Original-Ray")))
+		})
+	}
+}
+
+func TestCopyCloudFlareHeadersZoneScopedConnectingIPNotCopied(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
+	ctx := fasthttp.RequestCtx{}
+	req := fasthttp.Request{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("192.168.1.10")})
+
+	ctx.Request.Header.SetBytesV(CfConnectingIP, []byte("fe80::1%eth0"))
+
+	CopyCloudFlareHeaders(&ctx, &req)
+
+	assert.Empty(t, req.Header.Peek("Cf-Original-Connecting-Ip"))
+}
+
+func TestCopyCloudFlareHeadersUntrustedPeerCopiesNothing(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("192.168.1.0/24")}
+
+	ctx := fasthttp.RequestCtx{}
+	req := fasthttp.Request{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("203.0.113.10")})
+
+	ctx.Request.Header.SetBytesV(CfConnectingIP, []byte("1.2.3.4"))
+	ctx.Request.Header.SetBytesV("CfIndex", []byte("qwerty"))
+
+	CopyCloudFlareHeaders(&ctx, &req)
+
+	// A spoofed Cf-Connecting-IP from an untrusted peer must never reach the API as authoritative.
+	assert.Empty(t, req.Header.Peek("Cf-Original-Connecting-IP"))
+	assert.Empty(t, req.Header.Peek("Cf-Original-Index"))
+	assert.Zero(t, len(req.Header.PeekKeys()))
 }

--- a/headers/handler_test.go
+++ b/headers/handler_test.go
@@ -1,6 +1,8 @@
 package headers
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +12,12 @@ import (
 )
 
 func TestHandler(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
 	ctx := fasthttp.RequestCtx{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
 	ctx.Request.Header.Set(CfConnectingIP, "192.168.1.2")
 
 	h := Handler(func(ctx *fasthttp.RequestCtx) {})
@@ -19,6 +26,22 @@ func TestHandler(t *testing.T) {
 	ip := ctx.UserValueBytes(clientIpUserValue).(string)
 	assert.Equal(t, "192.168.1.2", ip)
 	assert.Equal(t, ContentTypeJson, ctx.Response.Header.ContentType())
+}
+
+func TestHandlerUntrustedPeerIgnoresHeader(t *testing.T) {
+	original := config.Global.TrustedProxies
+	t.Cleanup(func() { config.Global.TrustedProxies = original })
+	config.Global.TrustedProxies = []netip.Prefix{netip.MustParsePrefix("127.0.0.0/8")}
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: net.ParseIP("203.0.113.10")})
+	ctx.Request.Header.Set(CfConnectingIP, "192.168.1.2")
+
+	h := Handler(func(ctx *fasthttp.RequestCtx) {})
+	h(&ctx)
+
+	ip := ctx.UserValueBytes(clientIpUserValue).(string)
+	assert.Equal(t, "203.0.113.10", ip)
 }
 
 func TestHandlerAddTraceId(t *testing.T) {


### PR DESCRIPTION
## Problem statement

The gateway accepted `Cf-Connecting-IP`, `X-Real-IP` and `X-Forwarded-For` from any peer. Anyone able to reach it directly could claim an arbitrary client IP and rotate it per request. That value is not cosmetic — it keys guest rate limiting, it lands in request logs, it is sent to Google as the captcha score's remote IP, and it is forwarded upstream to the API, which reads `Cf-Original-Connecting-IP` ahead of `X-Forwarded-For` when rate limiting.

## Changes

- New `TRUSTED_PROXIES` config (CIDRs and bare IPs, parsed once at startup). IP headers are only consulted when the direct peer falls inside it; otherwise the real peer address is used.
- Only `Cf-Connecting-IP` is trusted. Cloudflare is the single hop that sets and overwrites its own header. `X-Forwarded-For` is appended to by every hop and `X-Real-IP` has no authoritative writer in this topology, so neither is trustworthy here.
- Every candidate is validated as a bare IP and zone-scoped addresses are rejected, rather than forwarding raw header bytes upstream.
- `CopyCloudFlareHeaders` is gated on the same trust check and validates `Cf-Connecting-IP` before copying it.

The default trusts the private ranges. On Docker Compose that means every container on the shared network, not Traefik alone — `.env.example` documents the trade-off and how to narrow it to a single address.

## Verification

- `make test` (`go test -race ./...`) — all 14 packages ok.
- `gofmt -l` clean, `go vet` clean.
- New coverage in `config_test.go` (CIDR/bare-IP parsing, malformed entries), `clientip_test.go` (trusted vs untrusted peer, malformed and zone-scoped candidates, header precedence) and `cloudflare_test.go` (copy gating, validation before copy).
- Independent review round completed with no material findings outstanding.
