### PR TITLE
feat(gateway): send a shared secret on requests forwarded to the API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ TRUSTED_PROXIES=
 
 CAPTCHA_SECRET=
 
+# Shared secret sent as X-Gateway-Secret on every request forwarded to the API. Empty =
+# disabled (header omitted). Must match the API's own GATEWAY_SECRET value.
+GATEWAY_SECRET=
+
 HTTPS_ENABLED=false
 HTTPS_CRT=
 HTTPS_KEY=

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Address       string
 	Compress      bool
 	CaptchaSecret string
+	GatewaySecret string
 
 	GatewayUrl string
 	ApiUrl     string
@@ -53,6 +54,7 @@ func (c *Config) Load() {
 	c.DebugHttp = getEnv("DEBUG_HTTP", "") == "true"
 	c.TraceCaptureBody = getEnv("TRACE_CAPTURE_BODY", "true") == "true"
 	c.CaptchaSecret = getEnv("CAPTCHA_SECRET", "")
+	c.GatewaySecret = getEnv("GATEWAY_SECRET", "")
 
 	c.ApiUrl = getEnv("API_URL", "")
 	if u, err := url.Parse(c.ApiUrl); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -132,3 +132,26 @@ func TestConfigLoadTrustedProxiesAllInvalidYieldsEmptyList(t *testing.T) {
 
 	assert.Empty(t, config.TrustedProxies)
 }
+
+func TestConfigLoadGatewaySecret(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "unset defaults to empty", env: "", want: ""},
+		{name: "set is loaded verbatim", env: "shared-secret-value", want: "shared-secret-value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv("API_URL", "http://api:80")
+			t.Setenv("GATEWAY_SECRET", tt.env)
+
+			config := &Config{}
+			config.Load()
+
+			assert.Equal(t, tt.want, config.GatewaySecret)
+		})
+	}
+}

--- a/headers/gatewaysecret.go
+++ b/headers/gatewaysecret.go
@@ -1,0 +1,8 @@
+package headers
+
+// WriteGatewaySecret marks the request as gateway-forwarded. No-op when secret is empty.
+func WriteGatewaySecret(h headerWriter, secret string) {
+	if secret != "" {
+		h.Set(XGatewaySecret, secret)
+	}
+}

--- a/headers/gatewaysecret_test.go
+++ b/headers/gatewaysecret_test.go
@@ -1,0 +1,24 @@
+package headers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+)
+
+func TestWriteGatewaySecretSet(t *testing.T) {
+	req := fasthttp.Request{}
+
+	WriteGatewaySecret(&req.Header, "shared-secret")
+
+	assert.Equal(t, "shared-secret", string(req.Header.Peek(XGatewaySecret)))
+}
+
+func TestWriteGatewaySecretEmpty(t *testing.T) {
+	req := fasthttp.Request{}
+
+	WriteGatewaySecret(&req.Header, "")
+
+	assert.Empty(t, req.Header.Peek(XGatewaySecret))
+}

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -33,6 +33,7 @@ const (
 	XCtGatewayVersion             = "X-Ct-Gateway-Version"
 	XCtTraceId                    = "X-Ct-Trace-Id"
 	XForwardedFor                 = "X-Forwarded-For"
+	XGatewaySecret                = "X-Gateway-Secret"
 	XRateLimit                    = "X-Ratelimit-Limit"
 	XRateLimitRemaining           = "X-Ratelimit-Remaining"
 	XRealIp                       = "X-Real-IP"

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -35,6 +35,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 
 	// set once: the refreshed-token retry below reuses this same req
 	headers.WriteGatewayVersion(&req.Header, s.config.GitTag, s.config.GitSha)
+	headers.WriteGatewaySecret(&req.Header, s.config.GatewaySecret)
 
 	headers.CopyFromRequest(ctx, req, []string{
 		headers.AcceptLanguage,

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -146,6 +146,111 @@ func TestForwardRequestOmitsGatewayVersionHeadersWhenEmpty(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestForwardRequestSetsGatewaySecretHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI:        apiUrl,
+		GatewaySecret: "shared-secret",
+	}, nil)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
+func TestForwardRequestOmitsGatewaySecretHeaderWhenEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Empty(t, req.Header.Peek(headers.XGatewaySecret))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
+// All three outbound requests of a 401-refresh-retry cycle must carry the shared secret:
+// the original forward, the refresh sub-request, and the retried forward.
+func TestForwardRequestGatewaySecretHeaderPersistsAcrossRefreshRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	// 1st: original forwarded request, gets 401
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+	// 2nd: refresh request, built with its own req in refresh_token.go
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+	// 3rd: retry, reusing the same req as the 1st
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI:        apiUrl,
+		GatewaySecret: "shared-secret",
+	}, nil)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
 // All three outbound requests of a 401-refresh-retry cycle must carry the headers.
 func TestForwardRequestGatewayVersionHeadersPersistAcrossRefreshRetry(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/service/api/healthcheck.go
+++ b/service/api/healthcheck.go
@@ -22,6 +22,7 @@ func (s *HttpService) Healthcheck() error {
 	req.Header.SetContentTypeBytes(headers.ContentTypeJson)
 	req.Header.SetBytesV(headers.Accept, headers.ContentTypeJson)
 	headers.WriteGatewayVersion(&req.Header, s.config.GitTag, s.config.GitSha)
+	headers.WriteGatewaySecret(&req.Header, s.config.GatewaySecret)
 
 	logger.DebugRequest(req, ServiceId)
 

--- a/service/api/healthcheck_test.go
+++ b/service/api/healthcheck_test.go
@@ -71,6 +71,53 @@ func TestHealthcheckSetsGatewayVersionHeaders(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHealthcheckSetsGatewaySecretHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI:        apiUrl,
+		GatewaySecret: "shared-secret",
+	}, nil)
+	err := s.Healthcheck()
+
+	assert.NoError(t, err)
+}
+
+func TestHealthcheckOmitsGatewaySecretHeaderWhenEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Empty(t, req.Header.Peek(headers.XGatewaySecret))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil)
+	err := s.Healthcheck()
+
+	assert.NoError(t, err)
+}
+
 func TestHealthcheckFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	h := mocks.NewHttpRetryClientMock(ctrl)

--- a/service/api/refresh_token.go
+++ b/service/api/refresh_token.go
@@ -33,6 +33,7 @@ func (s *HttpService) refreshToken(
 	req.Header.SetBytesV(headers.Accept, headers.ContentTypeJson)
 	headers.WriteBearerToken(req, auth.RefreshToken)
 	headers.WriteGatewayVersion(&req.Header, s.config.GitTag, s.config.GitSha)
+	headers.WriteGatewaySecret(&req.Header, s.config.GatewaySecret)
 
 	data, _ := json.Marshal(cookie.Auth{AccessToken: auth.AccessToken})
 	req.SetBody(data)

--- a/service/api/refresh_token_test.go
+++ b/service/api/refresh_token_test.go
@@ -95,6 +95,35 @@ func TestRefreshTokenSetsGatewayVersionHeaders(t *testing.T) {
 	assert.Equal(t, "new_access_token", newAuth.AccessToken)
 }
 
+func TestRefreshTokenSetsGatewaySecretHeader(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+
+		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI:        apiUrl,
+		GatewaySecret: "shared-secret",
+	}, nil)
+
+	auth := cookie.Auth{RefreshToken: "refresh_token", AccessToken: "access_token"}
+
+	newAuth, err := s.refreshToken(auth, context.TODO(), &fasthttp.RequestCtx{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "new_access_token", newAuth.AccessToken)
+}
+
 func TestRefreshTokenFail(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	h := mocks.NewHttpRetryClientMock(ctrl)


### PR DESCRIPTION
> Stacked on #48 — review that one first. Diff against `fix/trusted-proxy-client-ip`.

## Problem statement

The API is publicly routed at `api.${DOMAIN}`, so it cannot tell a request the gateway forwarded from one that reached it directly. Without a signal from the gateway, the API has no basis on which to trust the client-IP headers it receives — it can only strip everything, which would break real rate limiting for genuine traffic.

This is the gateway half of that fix. The API half is the companion PR in `cash-track/api`; the 1Password field and env wiring are in the `cash-track/infra` PR.

## Changes

- New `GATEWAY_SECRET` config (`getEnv("GATEWAY_SECRET", "")`).
- New `headers.WriteGatewaySecret`, which sets `X-Gateway-Secret` on the outbound request. It is a no-op when the secret is empty, so an unconfigured gateway behaves exactly as before.
- Called at all four outbound sites: the initial forward and the reused-request retry in `service/api/forward.go`, plus `service/api/refresh_token.go` and `service/api/healthcheck.go`.

## Verification

- `make test` (`go test -race ./...`) — all 14 packages ok; 110 tests across the 4 packages this touches.
- `gofmt -l` clean, `go vet` clean.
- New coverage asserts the header is written when the secret is set and omitted when it is empty, at each of the four call sites.
- End-to-end proof against a live stack is in the API PR: with the secret configured, requests carrying it kept per-client rate-limit buckets while requests without it collapsed to a single one.
- Independent review round completed with no material findings outstanding.

## Deployment ordering

`gateway-set / api-unset` is a pure no-op — the API simply ignores an unrecognised header — so this side is safe to deploy first and should be. Deploying the API side first opens a window where all gateway traffic is treated as untrusted. The sequence is documented in `api/docs/deployment/2026-08-07-gateway-trust-boundary.md`.
