### PR TITLE
feat(gateway): add API circuit breaker and Redis-tolerant CSRF

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -258,6 +258,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/register:
     post:
@@ -316,6 +318,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/provider/google:
     post:
@@ -373,6 +377,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/login/passkey:
     post:
@@ -425,6 +431,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/login/passkey/init:
     post:
@@ -469,6 +477,10 @@ paths:
           $ref: "#/components/responses/CaptchaError"
         "500":
           $ref: "#/components/responses/InternalError"
+        "502":
+          $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/logout:
     post:
@@ -571,6 +583,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
     post:
       operationId: proxyPost
       summary: Proxy POST request to backend
@@ -612,6 +626,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
     put:
       operationId: proxyPut
       summary: Proxy PUT request to backend
@@ -646,6 +662,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
     patch:
       operationId: proxyPatch
       summary: Proxy PATCH request to backend
@@ -680,6 +698,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
     delete:
       operationId: proxyDelete
       summary: Proxy DELETE request to backend
@@ -705,6 +725,8 @@ paths:
           $ref: "#/components/responses/InternalError"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
     options:
       operationId: proxyOptions
       summary: CORS preflight
@@ -767,6 +789,8 @@ paths:
               $ref: "#/components/headers/ContentSecurityPolicy"
         "502":
           $ref: "#/components/responses/BadGateway"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
 
 # =============================================================================
 # COMPONENTS
@@ -1210,7 +1234,7 @@ components:
 
     InternalError:
       description: |
-        HTTP 500. Three distinct origins share this status. Use the `X-Ct-Api-*` headers to
+        HTTP 500. Two distinct origins share this status. Use the `X-Ct-Api-*` headers to
         tell them apart: they are set by the backend and only ever relayed by the gateway, so
         their presence means the request reached the API.
 
@@ -1221,15 +1245,14 @@ components:
         2. **Captcha service failure**, on the captcha-gated auth routes only. The gateway could
            not get a usable answer from reCAPTCHA and rejected the request before forwarding.
            No `X-Ct-Api-*` headers.
-        3. **CSRF token rotation failure**, on authenticated `POST`/`PUT`/`PATCH`/`DELETE`.
-           Rotation runs *after* the backend has already replied, so the gateway overwrites the
-           status with `500` while leaving the backend's body and headers in place. The body
-           will therefore look like a success payload and `X-Ct-Api-*` headers **are** present.
-           The request itself was applied by the backend — only the new CSRF token was lost, and
-           the client recovers with `GET /csrf`.
 
-        A gateway failure to *reach* the backend is reported as `502` (see `BadGateway`), never
-        as `500`.
+        A background CSRF token rotation failure after a successful mutating request does
+        **not** produce a `500`: the gateway logs it and leaves the already-written response
+        untouched, so the client only notices on its *next* request via `GET /csrf`'s own `417`/
+        recovery flow.
+
+        A gateway failure to *reach* the backend is reported as `502` (see `BadGateway`) or,
+        while the circuit breaker is open, `503` (see `ServiceUnavailable`) — never as `500`.
       headers:
         X-Ct-Trace-Id:
           $ref: "#/components/headers/TraceId"
@@ -1239,14 +1262,14 @@ components:
           $ref: "#/components/headers/GatewaySha"
         X-Ct-Api-Version:
           description: |
-            Present when the response originated from the backend (origins 1 and 3 above),
+            Present when the response originated from the backend (origin 1 above),
             absent on a captcha failure (origin 2). See `#/components/headers/ApiVersion`.
           schema:
             type: string
             example: "v3.1.0"
         X-Ct-Api-Sha:
           description: |
-            Present when the response originated from the backend (origins 1 and 3 above),
+            Present when the response originated from the backend (origin 1 above),
             absent on a captcha failure (origin 2). See `#/components/headers/ApiSha`.
           schema:
             type: string
@@ -1295,6 +1318,55 @@ components:
           example:
             message: Unexpected error happened. Please try again later.
             error: ""
+
+    ServiceUnavailable:
+      description: |
+        HTTP 503. Two distinct origins share this status:
+
+        1. **Circuit breaker open.** Recent calls to the backend API have failed at the
+           transport level (timeout, connection refused, broken pipe — never a plain HTTP error
+           status), so the gateway rejects requests immediately instead of adding load to an
+           already-failing backend. The body is the gateway's standard JSON error shape and
+           `Retry-After` gives the number of seconds until the breaker allows another probe.
+           The `error` field is one of two strings, depending on which call the open breaker
+           rejected: `"API request error: circuit breaker is open"` for the initial forward, or
+           `"API request with fresh token error: circuit breaker is open"` for the retry issued
+           right after a successful access-token refresh. Both mean the same thing — the breaker
+           is open — and share the same `Retry-After` semantics; only the wrapping differs.
+        2. **Transient token-refresh failure.** The backend returned `401` for an expired access
+           token and the gateway's attempt to silently refresh it hit a transport error or
+           unexpected status. The session is preserved — auth cookies are left untouched — so
+           the client can safely retry the same request. The response has an **empty body** and
+           **no** `Retry-After` header.
+      headers:
+        X-Ct-Gateway-Version:
+          $ref: "#/components/headers/GatewayVersion"
+        X-Ct-Gateway-Sha:
+          $ref: "#/components/headers/GatewaySha"
+        Retry-After:
+          description: Present only on the circuit-breaker origin (1 above).
+          schema:
+            type: integer
+            example: 30
+        Strict-Transport-Security:
+          $ref: "#/components/headers/StrictTransportSecurity"
+        X-Content-Type-Options:
+          $ref: "#/components/headers/XContentTypeOptions"
+        X-Frame-Options:
+          $ref: "#/components/headers/XFrameOptions"
+        Referrer-Policy:
+          $ref: "#/components/headers/ReferrerPolicy"
+        Content-Security-Policy:
+          $ref: "#/components/headers/ContentSecurityPolicy"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            message: Unexpected error happened. Please try again later.
+            # Initial-forward wrapping shown here; see the description above for the
+            # equally-valid post-token-refresh-retry wrapping of the same origin.
+            error: "API request error: circuit breaker is open"
 
 # =============================================================================
 # GLOBAL SECURITY

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
+	github.com/prometheus/client_golang v1.20.4
 	github.com/redis/go-redis/extra/redisotel/v9 v9.8.0
 	github.com/redis/go-redis/v9 v9.8.0
+	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fasthttp v1.55.0
 	go.opentelemetry.io/otel v1.43.0
@@ -30,9 +32,9 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.20.4 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.59.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 h1:D0vL7YNisV2yqE55+q0lFuGse6U8lxlg7fYTctlT5Gc=
 github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/main.go
+++ b/main.go
@@ -41,11 +41,13 @@ func main() {
 
 	redisClient := getRedisClient()
 	csrf := csrfHandler.NewRedisHandler(redisClient)
+	breaker := apiService.NewBreaker()
+	apiService.RegisterBreakerMetrics(breaker)
 
 	r := router.New(
 		apiHandler.NewHttp(
 			config.Global,
-			apiService.NewHttp(retryhttp.NewFastHttpRetryClient(), config.Global, csrf),
+			apiService.NewHttp(retryhttp.NewFastHttpRetryClient(), config.Global, csrf, breaker),
 			captcha.NewGoogleReCaptchaProvider(retryhttp.NewFastHttpRetryClient(), config.Global),
 			csrf,
 		),

--- a/router/api/handler.go
+++ b/router/api/handler.go
@@ -2,12 +2,16 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
+	"strconv"
 
 	"github.com/valyala/fasthttp"
 
 	"github.com/cash-track/gateway/captcha"
 	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/headers"
 	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/router/csrf"
 	"github.com/cash-track/gateway/router/response"
@@ -74,9 +78,24 @@ func (h *HttpHandler) CaptchaVerifyHandler(ctx *fasthttp.RequestCtx) {
 func (h *HttpHandler) AuthResetHandler(ctx *fasthttp.RequestCtx) {
 	auth := cookie.ReadAuthCookie(ctx)
 
-	h.FullForwardedHandlerWithBody(ctx, cookie.Auth{
+	err := h.FullForwardedHandlerWithBody(ctx, cookie.Auth{
 		RefreshToken: auth.RefreshToken,
 	})
+	if err != nil {
+		log.Printf("logout: forwarding to backend failed, clearing cookies locally anyway: %v", err)
+	}
+
+	// The response is gateway-authored, so drop everything CopyFromResponse may have
+	// copied from the backend (Retry-After, X-Ratelimit-*, CORS, ...) rather than
+	// deleting headers one by one as that list grows.
+	//
+	// Reset() also clears the noDefaultContentType flag headers.Handler relies on, and
+	// leaves ContentType() non-nil but empty, so its fallback never fires. Both are
+	// re-asserted below.
+	ctx.Response.Reset()
+	ctx.Response.Header.SetNoDefaultContentType(true)
+	ctx.Response.Header.SetContentTypeBytes(headers.ContentTypeJson)
+	ctx.Response.SetStatusCode(fasthttp.StatusOK)
 
 	h.Logout(ctx)
 }
@@ -93,34 +112,49 @@ func (h *HttpHandler) FullForwardedHandler(ctx *fasthttp.RequestCtx) {
 
 	err := h.service.ForwardRequest(ctx, nil)
 	if err != nil {
-		response.ByErrorAndStatus(err, fasthttp.StatusBadGateway).Write(ctx)
+		writeForwardError(ctx, err)
 
 		return
 	}
 }
 
-func (h *HttpHandler) FullForwardedHandlerWithBody(ctx *fasthttp.RequestCtx, body any) {
+// FullForwardedHandlerWithBody forwards ctx with a JSON-marshaled body. It writes the
+// error response to ctx and also returns the failure, for callers that react to it.
+func (h *HttpHandler) FullForwardedHandlerWithBody(ctx *fasthttp.RequestCtx, body any) error {
 	if _, ok := allowedMethods[string(ctx.Request.Header.Method())]; !ok {
-		response.ByErrorAndStatus(
-			fmt.Errorf("request method %s is not allowed", ctx.Request.Header.Method()),
-			fasthttp.StatusBadRequest,
-		).Write(ctx)
+		err := fmt.Errorf("request method %s is not allowed", ctx.Request.Header.Method())
+		response.ByErrorAndStatus(err, fasthttp.StatusBadRequest).Write(ctx)
 
-		return
+		return err
 	}
 
 	b, err := json.Marshal(body)
 	if err != nil {
 		response.ByError(err).Write(ctx)
 
-		return
+		return err
 	}
 
 	if err := h.service.ForwardRequest(ctx, b); err != nil {
-		response.ByErrorAndStatus(err, fasthttp.StatusBadGateway).Write(ctx)
+		writeForwardError(ctx, err)
+
+		return err
+	}
+
+	return nil
+}
+
+// writeForwardError maps a ForwardRequest failure to a response: 503 with a Retry-After
+// hint when the circuit breaker is open, 502 for any other transport error.
+func writeForwardError(ctx *fasthttp.RequestCtx, err error) {
+	if errors.Is(err, api.ErrCircuitOpen) {
+		ctx.Response.Header.Set(headers.RetryAfter, strconv.Itoa(api.RetryAfterSeconds))
+		response.ByErrorAndStatus(err, fasthttp.StatusServiceUnavailable).Write(ctx)
 
 		return
 	}
+
+	response.ByErrorAndStatus(err, fasthttp.StatusBadGateway).Write(ctx)
 }
 
 func (h *HttpHandler) Healthcheck() error {

--- a/router/api/handler_test.go
+++ b/router/api/handler_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"fmt"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +11,10 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/headers"
 	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/mocks"
+	"github.com/cash-track/gateway/service/api"
 )
 
 func TestAuthSetHandler(t *testing.T) {
@@ -111,6 +115,112 @@ func TestAuthResetHandler(t *testing.T) {
 	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), fmt.Sprintf("%s=;", cookie.RefreshTokenCookieName))
 }
 
+// Logout stays effective when the forward fails, so an open breaker does not turn every
+// logout into a 503 for the whole timeout window.
+func TestAuthResetHandlerForwardError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token_test")
+
+	body := []byte(`{"refreshToken":"refresh_token_test"}`)
+
+	s.EXPECT().ForwardRequest(gomock.Any(), body).Return(fmt.Errorf("wrapped: %w", api.ErrCircuitOpen))
+
+	h.AuthResetHandler(&ctx)
+
+	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	assert.Empty(t, ctx.Response.Header.Peek(headers.RetryAfter))
+	assert.JSONEq(t, `{"redirectUrl":""}`, string(ctx.Response.Body()))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), fmt.Sprintf("%s=;", cookie.AccessTokenCookieName))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), fmt.Sprintf("%s=;", cookie.RefreshTokenCookieName))
+}
+
+// ForwardRequest returns nil on any completed round-trip and copies the backend's raw
+// status and headers onto ctx, so a backend 4xx/5xx must not leak into this always-200
+// endpoint.
+func TestAuthResetHandlerBackendErrorStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token_test")
+
+	body := []byte(`{"refreshToken":"refresh_token_test"}`)
+
+	s.EXPECT().ForwardRequest(gomock.Any(), body).DoAndReturn(func(ctx *fasthttp.RequestCtx, body []byte) error {
+		ctx.Response.SetStatusCode(fasthttp.StatusUnauthorized)
+		ctx.Response.Header.Set(headers.RetryAfter, "60")
+		ctx.Response.Header.SetContentType("text/html; charset=utf-8")
+
+		return nil
+	})
+
+	h.AuthResetHandler(&ctx)
+
+	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	assert.Equal(t, string(headers.ContentTypeJson), string(ctx.Response.Header.ContentType()))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.RetryAfter))
+	assert.JSONEq(t, `{"redirectUrl":""}`, string(ctx.Response.Body()))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), fmt.Sprintf("%s=;", cookie.AccessTokenCookieName))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), fmt.Sprintf("%s=;", cookie.RefreshTokenCookieName))
+}
+
+// Mocks only the HTTP transport so the real CopyFromResponse runs: a backend 429 carries
+// Retry-After, X-Ratelimit-* and its own Content-Type, none of which may leak here.
+func TestAuthResetHandlerBackendRateLimited(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	httpClient := mocks.NewHttpRetryClientMock(ctrl)
+	httpClient.EXPECT().WithReadTimeout(gomock.Any())
+	httpClient.EXPECT().WithWriteTimeout(gomock.Any())
+	httpClient.EXPECT().WithRetryAttempts(gomock.Any())
+	httpClient.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusTooManyRequests)
+		resp.Header.Set(headers.RetryAfter, "42")
+		resp.Header.Set(headers.XRateLimit, "60")
+		resp.Header.Set(headers.XRateLimitRemaining, "0")
+		resp.Header.SetContentType("application/json")
+		resp.SetBodyString(`{"message":"too many requests"}`)
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse("https://backend.test.com")
+	svc := api.NewHttp(httpClient, config.Config{ApiURI: apiUrl}, nil, api.NewBreaker())
+	h := NewHttp(config.Config{}, svc, c, &mockCSRFSeeder{})
+
+	uri := &fasthttp.URI{}
+	_ = uri.Parse(nil, []byte("https://gateway.test.com/api/auth/logout"))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token_test")
+	ctx.Request.SetURI(uri)
+
+	// The real middleware applies the default Content-Type after the inner handler, which
+	// is where a Response.Reset() can regress to text/plain or no Content-Type at all.
+	headers.Handler(func(ctx *fasthttp.RequestCtx) {
+		h.AuthResetHandler(ctx)
+	})(&ctx)
+
+	assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	assert.Equal(t, string(headers.ContentTypeJson), string(ctx.Response.Header.ContentType()))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.RetryAfter))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.XRateLimit))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.XRateLimitRemaining))
+	assert.JSONEq(t, `{"redirectUrl":""}`, string(ctx.Response.Body()))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), fmt.Sprintf("%s=;", cookie.AccessTokenCookieName))
+	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName)), fmt.Sprintf("%s=;", cookie.RefreshTokenCookieName))
+}
+
 func TestFullForwardedHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := mocks.NewApiServiceMock(ctrl)
@@ -145,6 +255,40 @@ func TestFullForwardedHandlerError(t *testing.T) {
 	h.FullForwardedHandler(&ctx)
 
 	assert.Equal(t, fasthttp.StatusBadGateway, ctx.Response.StatusCode())
+}
+
+func TestFullForwardedHandlerCircuitOpen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+
+	s.EXPECT().ForwardRequest(gomock.Any(), nil).Return(fmt.Errorf("wrapped: %w", api.ErrCircuitOpen))
+
+	h.FullForwardedHandler(&ctx)
+
+	assert.Equal(t, fasthttp.StatusServiceUnavailable, ctx.Response.StatusCode())
+	assert.Equal(t, strconv.Itoa(api.RetryAfterSeconds), string(ctx.Response.Header.Peek(headers.RetryAfter)))
+}
+
+func TestFullForwardedHandlerWithBodyCircuitOpen(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+
+	s.EXPECT().ForwardRequest(gomock.Any(), []byte(`{"test":"123"}`)).Return(fmt.Errorf("wrapped: %w", api.ErrCircuitOpen))
+
+	h.FullForwardedHandlerWithBody(&ctx, map[string]string{"test": "123"})
+
+	assert.Equal(t, fasthttp.StatusServiceUnavailable, ctx.Response.StatusCode())
+	assert.Equal(t, strconv.Itoa(api.RetryAfterSeconds), string(ctx.Response.Header.Peek(headers.RetryAfter)))
 }
 
 func TestFullForwardedHandlerRestrictedMethod(t *testing.T) {

--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -2,6 +2,7 @@ package csrf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -10,6 +11,8 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/redis/go-redis/v9"
 	"github.com/valyala/fasthttp"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,9 +26,40 @@ import (
 )
 
 const (
-	keyPrefix = "CT:csrf"
-	tokenTtl  = time.Minute * 10
+	keyPrefix         = "CT:csrf"
+	tokenTtl          = time.Minute * 10
+	metricsNamespace  = "gateway"
+	metricsCsrfSubsys = "csrf"
 )
+
+var csrfRotationFailedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsCsrfSubsys,
+	Name:      "rotation_failed_total",
+	Help:      "CSRF token rotations that failed after a successful response, leaving the response untouched.",
+})
+
+var csrfValidationFailedOpenTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsCsrfSubsys,
+	Name:      "validation_failed_open_total",
+	Help:      "CSRF validations that failed open because Redis was unreachable (not a missing/expired token).",
+})
+
+// csrfRedisUp is updated as requests flow through, not by a dedicated health check.
+var csrfRedisUp = newRedisUpGauge()
+
+func newRedisUpGauge() prometheus.Gauge {
+	g := promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsCsrfSubsys,
+		Name:      "redis_up",
+		Help:      "Whether the last CSRF Redis operation succeeded (1) or failed (0). Optimistic 1 before first use.",
+	})
+	g.Set(1)
+
+	return g
+}
 
 var (
 	csrfRequiredForMethods = map[string]bool{
@@ -131,8 +165,8 @@ func (r *RedisHandler) Handler(h fasthttp.RequestHandler) fasthttp.RequestHandle
 			if err != nil {
 				rotateSpan.RecordError(err)
 				rotateSpan.SetStatus(codes.Error, "rotate error")
-				log.Printf("Error on rotating CSRF token: %v", err)
-				ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+				log.Printf("ALERT: CSRF token rotation failed, response left as-is: %v", err)
+				csrfRotationFailedTotal.Inc()
 
 				return
 			}
@@ -239,18 +273,39 @@ func (r *RedisHandler) rotate(ctx context.Context, userCtx userContext) (string,
 	token := generateNewToken()
 
 	if err := r.client.SetEx(ctx, key, token, tokenTtl).Err(); err != nil {
+		csrfRedisUp.Set(0)
+
 		return "", fmt.Errorf("error on writing new token: %w", err)
 	}
+	csrfRedisUp.Set(1)
 
 	return token, nil
 }
 
+// verify checks the request's CSRF token against the one stored in Redis. A missing token
+// (redis.Nil) is a real failure and stays a 417. Any other error means Redis is
+// unreachable: fail open, since SameSite=Strict auth cookies already block classic CSRF
+// and this token is defence-in-depth only.
 func (r *RedisHandler) verify(ctx context.Context, userCtx userContext) error {
 	key := fmt.Sprintf("%s:%s", keyPrefix, userCtx.context)
 
-	if cmd := r.client.Get(ctx, key); cmd.Err() != nil {
-		return fmt.Errorf("error on reading token: %w", cmd.Err())
-	} else if strings.Compare(userCtx.cookie.Token, cmd.Val()) != 0 {
+	cmd := r.client.Get(ctx, key)
+	if err := cmd.Err(); err != nil {
+		if errors.Is(err, redis.Nil) {
+			csrfRedisUp.Set(1)
+
+			return fmt.Errorf("error on reading token: %w", err)
+		}
+
+		csrfRedisUp.Set(0)
+		log.Printf("ALERT: CSRF validation failed open, redis unreachable: %v", err)
+		csrfValidationFailedOpenTotal.Inc()
+
+		return nil
+	}
+	csrfRedisUp.Set(1)
+
+	if strings.Compare(userCtx.cookie.Token, cmd.Val()) != 0 {
 		log.Printf("CSRF token is invalid: requested %s stored %s", userCtx.cookie.Token, cmd.Val())
 
 		return fmt.Errorf("invalid CSRF token")

--- a/router/csrf/redis_handler_test.go
+++ b/router/csrf/redis_handler_test.go
@@ -22,8 +22,10 @@ func TestHandler(t *testing.T) {
 	for name, test := range map[string]struct {
 		request             *fasthttp.RequestCtx
 		setup               func(mock redismock.ClientMock)
+		innerHandler        func(ctx *fasthttp.RequestCtx)
 		expectPass          bool
 		expectStatus        int
+		expectBody          string
 		expectCsrfCookieSet bool
 	}{
 		"TokenValidForPost": {
@@ -109,7 +111,22 @@ func TestHandler(t *testing.T) {
 			},
 			expectPass: false,
 		},
-		"VerifyError": {
+		"VerifyRedisNilStaysFailedClosed": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:   false,
+			expectStatus: fasthttp.StatusExpectationFailed,
+		},
+		"VerifyConnectivityErrorFailsOpen": {
 			request: func() *fasthttp.RequestCtx {
 				ctx := fasthttp.RequestCtx{}
 				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -120,11 +137,18 @@ func TestHandler(t *testing.T) {
 			setup: func(mock redismock.ClientMock) {
 				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
 				mock.ExpectGet(key).SetErr(errors.New("broken pipe"))
+				mock.CustomMatch(func(expected, actual []interface{}) error {
+					assert.NotNil(t, actual)
+					if s, ok := actual[1].(string); ok {
+						assert.IsType(t, "", s)
+					}
+					return nil
+				}).ExpectSetEx(key, nil, 0).SetVal("token_1")
 			},
-			expectPass:   false,
-			expectStatus: fasthttp.StatusExpectationFailed,
+			expectPass:          true,
+			expectCsrfCookieSet: true,
 		},
-		"RotateError": {
+		"RotateErrorLeavesResponseUntouched": {
 			request: func() *fasthttp.RequestCtx {
 				ctx := fasthttp.RequestCtx{}
 				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -143,8 +167,15 @@ func TestHandler(t *testing.T) {
 					return nil
 				}).ExpectSetEx(key, nil, 0).SetErr(errors.New("broken pipe"))
 			},
-			expectPass:   true,
-			expectStatus: fasthttp.StatusInternalServerError,
+			// A real response, not fasthttp's 200 default, so "left as-is" is provable.
+			innerHandler: func(ctx *fasthttp.RequestCtx) {
+				ctx.Response.SetStatusCode(299)
+				ctx.Response.SetBodyString("preset-body")
+			},
+			expectPass:          true,
+			expectStatus:        299,
+			expectBody:          "preset-body",
+			expectCsrfCookieSet: false,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -157,6 +188,9 @@ func TestHandler(t *testing.T) {
 			handler := NewRedisHandler(client)
 			handler.Handler(func(ctx *fasthttp.RequestCtx) {
 				handlersExecuted = true
+				if test.innerHandler != nil {
+					test.innerHandler(ctx)
+				}
 			})(test.request)
 
 			assert.Equal(t, test.expectPass, handlersExecuted)
@@ -168,6 +202,9 @@ func TestHandler(t *testing.T) {
 			}
 			if test.expectStatus > 0 {
 				assert.Equal(t, test.expectStatus, test.request.Response.StatusCode())
+			}
+			if test.expectBody != "" {
+				assert.Equal(t, test.expectBody, string(test.request.Response.Body()))
 			}
 
 			if err := mock.ExpectationsWereMet(); err != nil {

--- a/service/api/breaker.go
+++ b/service/api/breaker.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sony/gobreaker/v2"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	breakerMaxRequests = 5
+	// Zero keeps failures counted across the whole closed state. A windowed reset would
+	// clear the count between slow failures, so a hanging backend would never trip.
+	breakerInterval         = time.Duration(0)
+	breakerTimeout          = 30 * time.Second
+	breakerFailureThreshold = 10
+	metricsNamespace        = "gateway"
+	metricsApiBreakerSubsys = "api_breaker"
+)
+
+// RetryAfterSeconds is the Retry-After hint sent with 503s while the breaker is open.
+const RetryAfterSeconds = int(breakerTimeout / time.Second)
+
+// ErrCircuitOpen lets callers tell a tripped breaker from a plain transport error.
+var ErrCircuitOpen = errors.New("circuit breaker is open")
+
+var breakerRejectedTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsApiBreakerSubsys,
+	Name:      "rejected_total",
+	Help:      "Requests rejected without hitting the API because the circuit breaker was open or half-open and full.",
+})
+
+// NewBreaker builds the API circuit breaker. Call once per process and share the
+// instance across requests.
+func NewBreaker() *gobreaker.CircuitBreaker[struct{}] {
+	return gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
+		Name:        ServiceId,
+		MaxRequests: breakerMaxRequests,
+		Interval:    breakerInterval,
+		Timeout:     breakerTimeout,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures > breakerFailureThreshold
+		},
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			log.Printf("[%s] circuit breaker state change: %s -> %s", name, from, to)
+		},
+	})
+}
+
+// RegisterBreakerMetrics exposes the breaker state on the default Prometheus registry.
+// Call once — a second call panics on duplicate registration.
+func RegisterBreakerMetrics(breaker *gobreaker.CircuitBreaker[struct{}]) {
+	promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: metricsApiBreakerSubsys,
+		Name:      "state",
+		Help:      "API circuit breaker state: 0=closed, 1=half-open, 2=open.",
+	}, func() float64 {
+		return float64(breaker.State())
+	})
+}
+
+// doWithBreaker runs the API call through the breaker. Transport errors pass through
+// unwrapped; a rejected call yields ErrCircuitOpen.
+func (s *HttpService) doWithBreaker(req *fasthttp.Request, resp *fasthttp.Response) error {
+	_, err := s.breaker.Execute(func() (struct{}, error) {
+		return struct{}{}, s.http.Do(req, resp)
+	})
+
+	if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+		breakerRejectedTotal.Inc()
+
+		return ErrCircuitOpen
+	}
+
+	return err
+}

--- a/service/api/breaker_test.go
+++ b/service/api/breaker_test.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/mocks"
+)
+
+// testBreaker returns a breaker with production settings. NewBreaker registers no
+// metrics, so each test can have its own.
+func testBreaker() *gobreaker.CircuitBreaker[struct{}] {
+	return NewBreaker()
+}
+
+func newTestService(t *testing.T, breaker *gobreaker.CircuitBreaker[struct{}]) (*HttpService, *mocks.HttpRetryClientMock) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiUrl}, nil, breaker)
+
+	return s, h
+}
+
+func TestDoWithBreakerOpensAfterConsecutiveTransportErrors(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	s, h := newTestService(t, testBreaker())
+
+	// breakerFailureThreshold consecutive failures keep the breaker closed; the next
+	// one trips it.
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(transportErr).Times(breakerFailureThreshold + 1)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	var err error
+	for i := 0; i < breakerFailureThreshold+1; i++ {
+		err = s.doWithBreaker(req, resp)
+		assert.ErrorIs(t, err, transportErr)
+	}
+
+	assert.Equal(t, gobreaker.StateOpen, s.breaker.State())
+
+	// Now open: rejected without reaching the transport, which the mock's call count proves.
+	err = s.doWithBreaker(req, resp)
+	assert.ErrorIs(t, err, ErrCircuitOpen)
+}
+
+func TestDoWithBreakerStaysClosedOn5xx(t *testing.T) {
+	s, h := newTestService(t, testBreaker())
+
+	attempts := breakerFailureThreshold + 5
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusInternalServerError)
+
+		return nil
+	}).Times(attempts)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	for i := 0; i < attempts; i++ {
+		err := s.doWithBreaker(req, resp)
+		assert.NoError(t, err)
+		assert.Equal(t, fasthttp.StatusInternalServerError, resp.StatusCode())
+	}
+
+	assert.Equal(t, gobreaker.StateClosed, s.breaker.State())
+}
+
+func TestForwardRequestErrorIsErrCircuitOpenWhenBreakerOpen(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	breaker := testBreaker()
+	s, h := newTestService(t, breaker)
+
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(transportErr).Times(breakerFailureThreshold + 1)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	for i := 0; i < breakerFailureThreshold+1; i++ {
+		_ = s.doWithBreaker(req, resp)
+	}
+
+	assert.Equal(t, gobreaker.StateOpen, breaker.State())
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.ErrorIs(t, err, ErrCircuitOpen)
+}
+
+func TestHealthcheckBypassesBreaker(t *testing.T) {
+	// A breaker that opens on the very first failure, so an open state is trivial to reach.
+	breaker := gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+	})
+
+	s, h := newTestService(t, breaker)
+
+	tripReq := fasthttp.AcquireRequest()
+	tripResp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(tripReq)
+	defer fasthttp.ReleaseResponse(tripResp)
+
+	gomock.InOrder(
+		h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(errors.New("connection refused")),
+		h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+			resp.SetStatusCode(fasthttp.StatusOK)
+
+			return nil
+		}),
+	)
+
+	err := s.doWithBreaker(tripReq, tripResp)
+	assert.Error(t, err)
+	assert.Equal(t, gobreaker.StateOpen, breaker.State())
+
+	// Healthcheck talks to the API directly and must succeed despite the open breaker.
+	err = s.Healthcheck()
+	assert.NoError(t, err)
+}
+
+func TestRegisterBreakerMetricsExposesState(t *testing.T) {
+	breaker := testBreaker()
+	RegisterBreakerMetrics(breaker)
+
+	expected := `
+# HELP gateway_api_breaker_state API circuit breaker state: 0=closed, 1=half-open, 2=open.
+# TYPE gateway_api_breaker_state gauge
+gateway_api_breaker_state 0
+`
+	assert.NoError(t, testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expected), "gateway_api_breaker_state"))
+}
+
+func TestBreakerHalfOpenRecovery(t *testing.T) {
+	breaker := gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
+		MaxRequests: 1,
+		Timeout:     20 * time.Millisecond,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 1
+		},
+	})
+
+	s, h := newTestService(t, breaker)
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	gomock.InOrder(
+		h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(errors.New("connection refused")),
+		h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+			resp.SetStatusCode(fasthttp.StatusOK)
+
+			return nil
+		}),
+	)
+
+	// 1st call fails and trips the breaker open.
+	err := s.doWithBreaker(req, resp)
+	assert.Error(t, err)
+	assert.Equal(t, gobreaker.StateOpen, breaker.State())
+
+	// Still within Timeout: rejected without reaching the transport.
+	err = s.doWithBreaker(req, resp)
+	assert.ErrorIs(t, err, ErrCircuitOpen)
+
+	time.Sleep(40 * time.Millisecond)
+
+	// Past Timeout: breaker probes with a single request, which succeeds.
+	err = s.doWithBreaker(req, resp)
+	assert.NoError(t, err)
+	assert.Equal(t, gobreaker.StateClosed, breaker.State())
+}

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -88,7 +88,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		fasthttp.ReleaseResponse(resp)
 	}()
 
-	if err := s.http.Do(req, resp); err != nil {
+	if err := s.doWithBreaker(req, resp); err != nil {
 		span.RecordError(err)
 
 		return fmt.Errorf("API request error: %w", err)
@@ -141,7 +141,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		defer retrySpan.End()
 
 		// execute request 2nd attempt
-		if err := s.http.Do(req, resp); err != nil {
+		if err := s.doWithBreaker(req, resp); err != nil {
 			retrySpan.RecordError(err)
 
 			return fmt.Errorf("API request with fresh token error: %w", err)

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -41,7 +41,7 @@ func TestFullForwardRequestWithAuth(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	uri := &fasthttp.URI{}
 	_ = uri.Parse(nil, []byte("https://gateway.test.com/api/auth/profile"))
@@ -77,7 +77,7 @@ func TestForwardRequestWithBodyOverride(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
@@ -108,7 +108,7 @@ func TestForwardRequestSetsGatewayVersionHeaders(t *testing.T) {
 		ApiURI: apiUrl,
 		GitTag: "v1.2.3",
 		GitSha: "abc123",
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -136,7 +136,7 @@ func TestForwardRequestOmitsGatewayVersionHeadersWhenEmpty(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -164,7 +164,7 @@ func TestForwardRequestSetsGatewaySecretHeader(t *testing.T) {
 	s := NewHttp(h, config.Config{
 		ApiURI:        apiUrl,
 		GatewaySecret: "shared-secret",
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -191,7 +191,7 @@ func TestForwardRequestOmitsGatewaySecretHeaderWhenEmpty(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -239,7 +239,7 @@ func TestForwardRequestGatewaySecretHeaderPersistsAcrossRefreshRetry(t *testing.
 	s := NewHttp(h, config.Config{
 		ApiURI:        apiUrl,
 		GatewaySecret: "shared-secret",
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -292,7 +292,7 @@ func TestForwardRequestGatewayVersionHeadersPersistAcrossRefreshRetry(t *testing
 		ApiURI: apiUrl,
 		GitTag: "v1.2.3",
 		GitSha: "abc123",
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -337,7 +337,7 @@ func TestForwardRequestWithAuthRefresh(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -376,7 +376,7 @@ func TestForwardRequestWithAuthRefreshExpiredLogsOut(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -409,7 +409,7 @@ func TestForwardRequestWithAuthRefreshTransientKeepsSession(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -446,7 +446,7 @@ func TestForwardRequestWithAuthRefreshApi5xxKeepsSession(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -494,7 +494,7 @@ func TestForwardRequestWithAuthRefreshSecondFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -517,7 +517,7 @@ func TestForwardRequestError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -559,7 +559,7 @@ func TestForwardRequestWithAuthRefreshSeedsCsrf(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, csrf)
+	}, csrf, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -598,7 +598,7 @@ func TestForwardRequestWithAuthRefreshCsrfSeedError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, csrf)
+	}, csrf, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -635,7 +635,7 @@ func TestForwardRequestWithAuthRefreshSecondFailNoSeed(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, csrf)
+	}, csrf, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
@@ -673,7 +673,7 @@ func TestForwardRequestWithAuthRefreshNon2xxNoSeed(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, csrf)
+	}, csrf, testBreaker())
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)

--- a/service/api/healthcheck_test.go
+++ b/service/api/healthcheck_test.go
@@ -39,7 +39,7 @@ func TestHealthcheckOk(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestHealthcheckSetsGatewayVersionHeaders(t *testing.T) {
 		ApiURI: apiUrl,
 		GitTag: "v1.2.3",
 		GitSha: "abc123",
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.NoError(t, err)
@@ -89,7 +89,7 @@ func TestHealthcheckSetsGatewaySecretHeader(t *testing.T) {
 	s := NewHttp(h, config.Config{
 		ApiURI:        apiUrl,
 		GatewaySecret: "shared-secret",
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.NoError(t, err)
@@ -112,7 +112,7 @@ func TestHealthcheckOmitsGatewaySecretHeaderWhenEmpty(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.NoError(t, err)
@@ -133,7 +133,7 @@ func TestHealthcheckFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.Error(t, err)
@@ -150,7 +150,7 @@ func TestHealthcheckError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 	err := s.Healthcheck()
 
 	assert.Error(t, err)

--- a/service/api/refresh_token.go
+++ b/service/api/refresh_token.go
@@ -60,7 +60,7 @@ func (s *HttpService) refreshToken(
 	defer span.End()
 
 	newAuth := cookie.Auth{}
-	err := s.http.Do(req, resp)
+	err := s.doWithBreaker(req, resp)
 	if err != nil {
 		span.RecordError(err)
 

--- a/service/api/refresh_token_test.go
+++ b/service/api/refresh_token_test.go
@@ -49,7 +49,7 @@ func TestRefreshTokenOk(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{
 		RefreshToken: oldRefreshToken,
@@ -85,7 +85,7 @@ func TestRefreshTokenSetsGatewayVersionHeaders(t *testing.T) {
 		ApiURI: apiUrl,
 		GitTag: "v1.2.3",
 		GitSha: "abc123",
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{RefreshToken: "refresh_token", AccessToken: "access_token"}
 
@@ -114,7 +114,7 @@ func TestRefreshTokenSetsGatewaySecretHeader(t *testing.T) {
 	s := NewHttp(h, config.Config{
 		ApiURI:        apiUrl,
 		GatewaySecret: "shared-secret",
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{RefreshToken: "refresh_token", AccessToken: "access_token"}
 
@@ -140,7 +140,7 @@ func TestRefreshTokenFail(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{}
 
@@ -162,7 +162,7 @@ func TestRefreshTokenError(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{}
 
@@ -189,7 +189,7 @@ func TestRefreshTokenErrorBadResponse(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{}
 
@@ -216,7 +216,7 @@ func TestRefreshTokenErrorLoggedOff(t *testing.T) {
 	apiUrl, _ := url.Parse(endpoint)
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	auth := cookie.Auth{}
 

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sony/gobreaker/v2"
 	"github.com/valyala/fasthttp"
 
 	"github.com/cash-track/gateway/config"
@@ -30,20 +31,27 @@ type Service interface {
 }
 
 type HttpService struct {
-	http   retryhttp.Client
-	config config.Config
-	csrf   csrf.CSRFSeeder
+	http    retryhttp.Client
+	config  config.Config
+	csrf    csrf.CSRFSeeder
+	breaker *gobreaker.CircuitBreaker[struct{}]
 }
 
-func NewHttp(http retryhttp.Client, config config.Config, csrf csrf.CSRFSeeder) *HttpService {
+func NewHttp(
+	http retryhttp.Client,
+	config config.Config,
+	csrf csrf.CSRFSeeder,
+	breaker *gobreaker.CircuitBreaker[struct{}],
+) *HttpService {
 	http.WithReadTimeout(httpReadTimeout)
 	http.WithWriteTimeout(httpWriteTimeout)
 	http.WithRetryAttempts(httpRetryAttempts)
 
 	return &HttpService{
-		http:   http,
-		config: config,
-		csrf:   csrf,
+		http:    http,
+		config:  config,
+		csrf:    csrf,
+		breaker: breaker,
 	}
 }
 

--- a/service/api/service_test.go
+++ b/service/api/service_test.go
@@ -19,7 +19,7 @@ func TestNewClient(t *testing.T) {
 	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 
-	s := NewHttp(h, config.Config{}, nil)
+	s := NewHttp(h, config.Config{}, nil, testBreaker())
 
 	assert.NotNil(t, s.http)
 }
@@ -34,7 +34,7 @@ func TestSetRequestURI(t *testing.T) {
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	uri := fasthttp.URI{}
 
@@ -53,7 +53,7 @@ func TestCopyRequestURI(t *testing.T) {
 	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
 	s := NewHttp(h, config.Config{
 		ApiURI: apiUrl,
-	}, nil)
+	}, nil, testBreaker())
 
 	src := fasthttp.URI{}
 	src.SetPath("/api/users/create one")


### PR DESCRIPTION
> Stacked on #50 — review that one first. Diff against `feat/security-response-headers`.

## Problem statement

Two failure modes, both of which turn a partial outage into a worse one.

**No circuit breaker.** When the API is unreachable at the transport level, every forwarded request pays the full 5s read timeout before failing. Under load that pins gateway workers on calls that are already known to fail.

**CSRF is fully coupled to Redis.** Two distinct bugs: a rotation failure *after* a successful response stamped a 500 over a response the client had already earned, and any Redis error during validation returned 417 — so a Redis blip locked every user out of a gateway that was otherwise perfectly healthy.

## Changes

### Circuit breaker (P2-2)

- `sony/gobreaker/v2` wraps the gateway→API calls. Open → **503** in the gateway's JSON error shape with a `Retry-After` hint, without touching the API.
- `Healthcheck()` deliberately **bypasses** the breaker, so `/ready` keeps reporting the API's true state rather than the breaker's opinion of it.
- New metrics on the existing `/metrics`: `gateway_api_breaker_state` (0=closed, 1=half-open, 2=open) and `gateway_api_breaker_rejected_total`.

Two settings decisions worth calling out, both departures from the original ticket:

- **Only transport errors count as failures — a 5xx does not.** Otherwise one buggy endpoint returning 500 opens the breaker for *all* traffic, converting a partial outage into a total one.
- **`Interval` is 0, not a 10s window.** gobreaker clears its counters on the interval boundary while closed (`toNewGeneration` → `counts.clear()`). With a 5s read timeout, a backend that *hangs* accrues ~2 failures per window and never reaches the threshold — the breaker would only ever work against connection-refused, which is instant and cheap and least needs a breaker. Consecutive counting already resets on any success, so the window contributed nothing but the bug.

### CSRF resilience (P2-3)

- Post-response rotation failure now logs and increments `csrf_rotation_failed_total`, leaving the response untouched. `GET /csrf` still returns 500 on rotation failure, which is correct — there the token *is* the product.
- Validation **fails open on connectivity errors only**. `redis.Nil` (expired or never seeded) and a mismatched token still return 417. This distinction is the whole point: failing open on `redis.Nil` would make every expired token a silent CSRF bypass, which is worse than the bug being fixed. Auth cookies are `SameSite=Strict`, so classic CSRF is already blocked at the browser layer and this token is defence-in-depth.
- New `gateway_csrf_redis_up`, `csrf_validation_failed_open_total`, `csrf_rotation_failed_total`.

**Redis is deliberately not added to `/ready`.** Nothing polls it — the gateway service has no `healthcheck:` block and Traefik has no loadbalancer health check for it — and it contradicts fail-open: a gateway that can still serve traffic would mark itself unhealthy, which becomes a restart loop the moment `/ready` is wired up under `restart: always`. The metric covers the observability need without that risk.

### Logout

`POST /api/auth/logout` documents an always-200 contract, but the breaker turns a rare backend blip into a systematic 30s window, so it had to survive one. It now resets its response and re-authors it: 200, `application/json`, redirect body, cleared cookies — regardless of what the backend returned or whether the forward failed at all. Clearing cookies is purely local, so logout works during a full API outage.

The reset is used rather than deleting headers one by one because `CopyFromResponse` copies a growing list from the backend (`Retry-After`, `X-Ratelimit-*`, CORS, `Content-Type`); enumerating them is a shape that breaks every time that list grows.

## Verification

- `make test` (`go test -race`) — 245 tests across 17 packages. `go vet` clean, `golangci-lint run ./...` 0 issues, `redocly lint` unchanged from baseline.
- Three independent review rounds. All three found a defect in `AuthResetHandler` — an unconditional logout after a failed forward, then a reset wrongly gated on the error being non-nil (`ForwardRequest` returns nil on any *completed* round-trip and copies the backend's raw status onto ctx), then only `Retry-After` being stripped while `X-Ratelimit-*` leaked. The fix replaced header-by-header patching with a full `Response.Reset()`.
- Verified against **vendored fasthttp source**, not by reasoning: `Response.Header.Reset()` clears the `noDefaultContentType` flag, and even once re-asserted, `ContentType()` returns an empty-but-non-nil slice so `headers.Handler`'s nil check never fires and no `Content-Type` ships at all. Both corrected explicitly.
- **Verified on a running gateway**, not only in unit tests:

| Case | Result |
|---|---|
| 11 sequential failures vs. a **hanging** backend | Failures accumulate across 55s, breaker opens at request 11 |
| Request 12, breaker open | 503 + `Retry-After: 30` in **0.04s**, down from 5.05s |
| Same scenario before the `Interval` fix | Breaker stayed closed indefinitely — never tripped |
| 18 consecutive backend 500s | Breaker stays closed, real 500 passed through |
| `/ready` while breaker open | Still reports the API's true state |
| Open → half-open → closed | Half-open after `Timeout`; closes on the 5th consecutive success |
| Logout, breaker open | 200 + JSON + cleared cookies, no `Retry-After`/`X-Ratelimit-*` |
| Logout, backend 429 with the full header trio | Same clean 200 — proves the reset, not a no-op |
| CSRF, Redis up, token expired/mismatched | 417 (unchanged) |
| CSRF, Redis paused mid-flight | Request passes through, `csrf_validation_failed_open_total` increments, `gateway_csrf_redis_up` → 0 |

## Follow-up not in this PR

The gateway silently retries idempotent requests up to 5× (`fasthttp`'s `DefaultMaxIdemponentCallAttempts`; the early break on non-`io.EOF` errors applies only to non-idempotent methods). Against a hanging backend a client GET therefore costs 25s versus a POST's 5s. It is pre-existing, affects every forwarded request, and the retry exists for a real reason — a server closing an idle keep-alive connection — so it belongs in its own change rather than bundled here.
