### PR TITLE
fix(gateway): guard against zero-value cookie expiry on malformed auth response

### DIFF
--- a/headers/cookie/auth.go
+++ b/headers/cookie/auth.go
@@ -1,6 +1,7 @@
 package cookie
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -35,16 +36,23 @@ func ReadAuthCookie(ctx *fasthttp.RequestCtx) Auth {
 	return auth
 }
 
-func (a Auth) WriteCookie(ctx *fasthttp.RequestCtx) {
+func (a Auth) WriteCookie(ctx *fasthttp.RequestCtx) error {
 	if !a.IsLogged() {
 		ctx.Response.Header.SetCookie(newCookie(AccessTokenCookieName, "", fasthttp.CookieExpireDelete))
 		ctx.Response.Header.SetCookie(newCookie(RefreshTokenCookieName, "", fasthttp.CookieExpireDelete))
 
-		return
+		return nil
 	}
 
-	ctx.Response.Header.SetCookie(newCookie(AccessTokenCookieName, a.AccessToken, a.GetRefreshTokenExpireDate()))
-	ctx.Response.Header.SetCookie(newCookie(RefreshTokenCookieName, a.RefreshToken, a.GetRefreshTokenExpireDate()))
+	expireAt, err := a.GetRefreshTokenExpireDate()
+	if err != nil {
+		return fmt.Errorf("refresh token expiry: %w", err)
+	}
+
+	ctx.Response.Header.SetCookie(newCookie(AccessTokenCookieName, a.AccessToken, expireAt))
+	ctx.Response.Header.SetCookie(newCookie(RefreshTokenCookieName, a.RefreshToken, expireAt))
+
+	return nil
 }
 
 func (a Auth) IsLogged() bool {
@@ -55,10 +63,17 @@ func (a Auth) CanRefresh() bool {
 	return a.RefreshToken != ""
 }
 
-func (a Auth) GetRefreshTokenExpireDate() time.Time {
-	t, _ := time.Parse(time.RFC3339, a.RefreshTokenExpiredAt)
+func (a Auth) GetRefreshTokenExpireDate() (time.Time, error) {
+	t, err := time.Parse(time.RFC3339, a.RefreshTokenExpiredAt)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse refresh token expiry %q: %w", a.RefreshTokenExpiredAt, err)
+	}
 
-	return t
+	if t.Before(time.Now()) {
+		return time.Time{}, fmt.Errorf("refresh token expiry %q is in the past", a.RefreshTokenExpiredAt)
+	}
+
+	return t, nil
 }
 
 func (a Auth) GetOpenTelemetryAttributes() []attribute.KeyValue {

--- a/headers/cookie/auth_test.go
+++ b/headers/cookie/auth_test.go
@@ -84,7 +84,9 @@ func TestWriteAuthCookie(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := fasthttp.RequestCtx{}
 
-			test.Auth.WriteCookie(&ctx)
+			err := test.Auth.WriteCookie(&ctx)
+
+			assert.NoError(t, err)
 
 			access := ctx.Response.Header.PeekCookie(AccessTokenCookieName)
 			assert.Contains(t, string(access), AccessTokenCookieName)
@@ -110,6 +112,78 @@ func TestWriteAuthCookie(t *testing.T) {
 			assert.Contains(t, string(refresh), test.ExpectedRefreshToken)
 			assert.Contains(t, string(refresh), fmt.Sprintf("expires=%s", expire))
 
+		})
+	}
+}
+
+func TestWriteAuthCookieMalformedRefreshExpiryWritesNoCookies(t *testing.T) {
+	config.Global.CookieDomain = "test.domain.com"
+	config.Global.CookieSecure = true
+
+	yesterday := time.Now().Add(-time.Hour * 24).Format(time.RFC3339)
+
+	for name, refreshTokenExpiredAt := range map[string]string{
+		"Empty":   "",
+		"Garbage": "not-a-timestamp",
+		"Past":    yesterday,
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := fasthttp.RequestCtx{}
+
+			auth := Auth{
+				AccessToken:           "123",
+				RefreshToken:          "123123",
+				RefreshTokenExpiredAt: refreshTokenExpiredAt,
+			}
+
+			err := auth.WriteCookie(&ctx)
+
+			assert.Error(t, err)
+			assert.Empty(t, ctx.Response.Header.PeekCookie(AccessTokenCookieName))
+			assert.Empty(t, ctx.Response.Header.PeekCookie(RefreshTokenCookieName))
+		})
+	}
+}
+
+func TestAuth_GetRefreshTokenExpireDate(t *testing.T) {
+	tomorrow := time.Now().Add(time.Hour * 24)
+	yesterday := time.Now().Add(-time.Hour * 24)
+
+	for name, test := range map[string]struct {
+		RefreshTokenExpiredAt string
+		ExpectError           bool
+	}{
+		"ValidFuture": {
+			RefreshTokenExpiredAt: tomorrow.Format(time.RFC3339),
+			ExpectError:           false,
+		},
+		"Empty": {
+			RefreshTokenExpiredAt: "",
+			ExpectError:           true,
+		},
+		"Garbage": {
+			RefreshTokenExpiredAt: "not-a-timestamp",
+			ExpectError:           true,
+		},
+		"Past": {
+			RefreshTokenExpiredAt: yesterday.Format(time.RFC3339),
+			ExpectError:           true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			auth := Auth{RefreshTokenExpiredAt: test.RefreshTokenExpiredAt}
+
+			expireAt, err := auth.GetRefreshTokenExpireDate()
+
+			if test.ExpectError {
+				assert.Error(t, err)
+				assert.True(t, expireAt.IsZero())
+
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.WithinDuration(t, tomorrow, expireAt, time.Second)
 		})
 	}
 }

--- a/router/api/handler_test.go
+++ b/router/api/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -44,10 +45,12 @@ func TestAuthSetHandler(t *testing.T) {
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
 	ctx.Request.Header.Set("Test", "Value")
 
+	tomorrow := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+
 	c.EXPECT().Verify(gomock.Any()).Return(true, nil)
 	s.EXPECT().ForwardRequest(gomock.Any(), nil).DoAndReturn(func(ctx *fasthttp.RequestCtx, body []byte) error {
 		ctx.Response.SetStatusCode(fasthttp.StatusOK)
-		ctx.Response.SetBodyString(`{"accessToken":"new_access_token"}`)
+		ctx.Response.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshTokenExpiredAt":"%s"}`, tomorrow))
 		return nil
 	})
 

--- a/router/api/login.go
+++ b/router/api/login.go
@@ -21,7 +21,9 @@ func (h *HttpHandler) Login(ctx *fasthttp.RequestCtx) error {
 		return fmt.Errorf("login response body invalid: %w", err)
 	}
 
-	auth.WriteCookie(ctx)
+	if err := auth.WriteCookie(ctx); err != nil {
+		return fmt.Errorf("login write cookie: %w", err)
+	}
 
 	// Seed the initial CSRF token. Non-fatal: if Redis is unavailable the user
 	// will recover automatically on their first mutation via GET /csrf.

--- a/router/api/login_test.go
+++ b/router/api/login_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -31,9 +33,11 @@ func TestLogin(t *testing.T) {
 	csrf := &mockCSRFSeeder{}
 	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
 
+	tomorrow := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+
 	ctx := fasthttp.RequestCtx{}
 	ctx.Response.SetStatusCode(fasthttp.StatusOK)
-	ctx.Response.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+	ctx.Response.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrow))
 
 	err := h.Login(&ctx)
 
@@ -90,9 +94,11 @@ func TestLoginSeedError(t *testing.T) {
 	csrf := &mockCSRFSeeder{err: assert.AnError}
 	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
 
+	tomorrow := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+
 	ctx := fasthttp.RequestCtx{}
 	ctx.Response.SetStatusCode(fasthttp.StatusOK)
-	ctx.Response.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+	ctx.Response.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrow))
 
 	// Seed failure is non-fatal: login still succeeds, user recovers via GET /csrf
 	err := h.Login(&ctx)
@@ -100,4 +106,50 @@ func TestLoginSeedError(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName)), "new_access_token")
 	assert.True(t, csrf.called)
+}
+
+func TestLoginMalformedRefreshExpiry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	csrf := &mockCSRFSeeder{}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Response.SetStatusCode(fasthttp.StatusOK)
+	ctx.Response.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"not-a-timestamp"}`)
+
+	err := h.Login(&ctx)
+
+	assert.Error(t, err)
+	assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName))
+	assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName))
+	assert.False(t, csrf.called, "Seed must NOT be called when the cookie write fails")
+}
+
+// TestAuthSetHandlerMalformedRefreshExpiryReturns502 exercises the full handler chain
+// (AuthSetHandler -> Login) to confirm a malformed refreshTokenExpiredAt from the
+// backend surfaces as a 502, per writeForwardError/response.ByErrorAndStatus mapping.
+func TestAuthSetHandlerMalformedRefreshExpiryReturns502(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	csrf := &mockCSRFSeeder{}
+	h := NewHttp(config.Config{WebAppUrl: "https://home.com"}, s, c, csrf)
+
+	c.EXPECT().Verify(gomock.Any()).Return(true, nil)
+	s.EXPECT().ForwardRequest(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx *fasthttp.RequestCtx, _ []byte) error {
+		ctx.Response.SetStatusCode(fasthttp.StatusOK)
+		ctx.Response.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"not-a-timestamp"}`)
+
+		return nil
+	})
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+
+	h.AuthSetHandler(&ctx)
+
+	assert.Equal(t, fasthttp.StatusBadGateway, ctx.Response.StatusCode())
+	assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName))
 }

--- a/router/api/logout.go
+++ b/router/api/logout.go
@@ -7,7 +7,9 @@ import (
 )
 
 func (h *HttpHandler) Logout(ctx *fasthttp.RequestCtx) {
-	cookie.Auth{}.WriteCookie(ctx)
+	// Auth{} is never "logged" (AccessToken == ""), so this always takes the
+	// delete branch and cannot fail — error structurally impossible here.
+	_ = cookie.Auth{}.WriteCookie(ctx)
 
 	b, _ := h.newWebsiteRedirect().ToJson()
 

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -183,9 +183,13 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		}
 	}
 
-	// err == nil and not logged ⇒ refresh token genuinely expired/invalid.
-	// Logging out (cookie deletion) is the correct behaviour here.
-	newAuth.WriteCookie(ctx)
+	// This is also reached when newAuth is not logged (refresh token genuinely
+	// expired/invalid) ⇒ WriteCookie takes the delete branch, logging the user out.
+	if err := newAuth.WriteCookie(ctx); err != nil {
+		span.RecordError(err)
+
+		return fmt.Errorf("write auth cookie after refresh: %w", err)
+	}
 
 	return forwardResponse(ctx, resp)
 }

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -16,6 +17,12 @@ import (
 	"github.com/cash-track/gateway/headers/cookie"
 	"github.com/cash-track/gateway/mocks"
 )
+
+// tomorrowRFC3339 returns a valid future RefreshTokenExpiredAt value for tests that
+// need refreshed auth to pass WriteCookie's expiry validation.
+func tomorrowRFC3339() string {
+	return time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+}
 
 func TestFullForwardRequestWithAuth(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -220,7 +227,7 @@ func TestForwardRequestGatewaySecretHeaderPersistsAcrossRefreshRetry(t *testing.
 	// 2nd: refresh request, built with its own req in refresh_token.go
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 
 		assert.Equal(t, "shared-secret", string(req.Header.Peek(headers.XGatewaySecret)))
 
@@ -270,7 +277,7 @@ func TestForwardRequestGatewayVersionHeadersPersistAcrossRefreshRetry(t *testing
 	// 2nd: refresh request, built with its own req in refresh_token.go
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 
 		assert.Equal(t, "v1.2.3", string(req.Header.Peek(headers.XCtGatewayVersion)))
 		assert.Equal(t, "abc123", string(req.Header.Peek(headers.XCtGatewaySha)))
@@ -321,7 +328,7 @@ func TestForwardRequestWithAuthRefresh(t *testing.T) {
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"%s","refreshToken":"%s"}`, "new_access_token", "new_refresh_token"))
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"%s","refreshToken":"%s","refreshTokenExpiredAt":"%s"}`, "new_access_token", "new_refresh_token", tomorrowRFC3339()))
 		return nil
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
@@ -479,7 +486,7 @@ func TestForwardRequestWithAuthRefreshSecondFail(t *testing.T) {
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"%s","refreshToken":"%s"}`, "new_access_token", "new_refresh_token"))
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"%s","refreshToken":"%s","refreshTokenExpiredAt":"%s"}`, "new_access_token", "new_refresh_token", tomorrowRFC3339()))
 
 		return nil
 	})
@@ -541,7 +548,7 @@ func TestForwardRequestWithAuthRefreshSeedsCsrf(t *testing.T) {
 	// Second call: refresh endpoint returns new tokens
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 		return nil
 	})
 	// Third call: retried original request succeeds
@@ -584,7 +591,7 @@ func TestForwardRequestWithAuthRefreshCsrfSeedError(t *testing.T) {
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 		return nil
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
@@ -624,7 +631,7 @@ func TestForwardRequestWithAuthRefreshSecondFailNoSeed(t *testing.T) {
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 		return nil
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(fmt.Errorf("broken pipe"))
@@ -659,7 +666,7 @@ func TestForwardRequestWithAuthRefreshNon2xxNoSeed(t *testing.T) {
 	})
 	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
 		resp.SetStatusCode(fasthttp.StatusOK)
-		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token"}`)
+		resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
 		return nil
 	})
 	// Retried request returns 500 — Seed must NOT be called.
@@ -684,6 +691,50 @@ func TestForwardRequestWithAuthRefreshNon2xxNoSeed(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+}
+
+// TestForwardRequestWithAuthRefreshMalformedExpiryReturnsError covers the fail-closed
+// guard: a backend refresh response with a malformed refreshTokenExpiredAt must not
+// result in a broken cookie being written. ForwardRequest must return an error instead
+// (mapped to a 502 by writeForwardError in the handler layer).
+func TestForwardRequestWithAuthRefreshMalformedExpiryReturnsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	// 1st: original forwarded request, gets 401
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	// 2nd: refresh succeeds but the backend sent a malformed refreshTokenExpiredAt
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"not-a-timestamp"}`)
+		return nil
+	})
+	// 3rd: retried original request succeeds
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil, testBreaker())
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.Error(t, err)
+	assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.AccessTokenCookieName))
+	assert.Empty(t, ctx.Response.Header.PeekCookie(cookie.RefreshTokenCookieName))
 }
 
 func TestForwardResponse(t *testing.T) {


### PR DESCRIPTION
## Problem statement

`headers/cookie/auth.go`'s `WriteCookie` parsed `RefreshTokenExpiredAt` from the backend auth response and used it directly as the cookie expiry, without validating the result. A malformed or missing value from the backend silently parsed to a zero-value or otherwise nonsensical expiry, so the gateway would write a broken access/refresh cookie instead of failing loudly.

## Changes

- `headers/cookie/auth.go`: `GetRefreshTokenExpireDate()` now returns `(time.Time, error)`, erroring when the timestamp fails to parse or is already in the past. `WriteCookie()` now returns `error` and writes no cookies at all when that validation fails (both cookies are gated behind a single check — no partial write).
- `router/api/login.go`: `Login()` propagates the `WriteCookie` error. `AuthSetHandler` already maps any `Login()` error to a 502 response, so malformed login responses now surface as 502 instead of a silently broken session cookie.
- `service/api/forward.go`: the cookie write after a successful token-refresh retry now short-circuits with an error instead of falling through to `forwardResponse` on failure. `FullForwardedHandler`/`writeForwardError` already map non-circuit-breaker `ForwardRequest` errors to 502.
- `router/api/logout.go`: updated the call site to `_ = cookie.Auth{}.WriteCookie(ctx)`, matching the file's existing convention for discarding errors that are structurally impossible at that call site (an empty `Auth{}` is never "logged", so it always takes the nil-returning cookie-deletion branch).
- `headers/cookie/csrf.go`'s unrelated `CSRF.WriteCookie` (own fixed TTL, doesn't touch refresh-token expiry) is untouched.

## Verification

- `go test -race ./...` — 263 tests passing across 17 packages.
- 100% statement coverage on all three touched packages (`headers/cookie`, `router/api`, `service/api`), including every new/changed function.
- `go vet ./...` and `golangci-lint run` — clean.
- Independent code review: no material findings (past-timestamp boundary, no-partial-write behavior, control flow after the changed call sites, and the discarded-error reasoning in `logout.go` all verified).
- Independent test pass, including live exercise against the running local dev stack: login sets `cshtrka`/`cshtrkr`/`cshtrkcsrf` with matching, correct expiry; authenticated CSRF-protected request succeeds; logout correctly deletes both auth cookies. New tests cover the malformed/expired-timestamp paths end-to-end (`Login()` and the refresh-retry path both surface as 502 with no cookie set).
