### PR TITLE
feat(gateway): send refresh token in body instead of Authorization header

### DIFF
--- a/service/api/refresh_token.go
+++ b/service/api/refresh_token.go
@@ -31,11 +31,10 @@ func (s *HttpService) refreshToken(
 	s.setRequestURI(req.URI(), refreshURI)
 	req.Header.SetContentTypeBytes(headers.ContentTypeJson)
 	req.Header.SetBytesV(headers.Accept, headers.ContentTypeJson)
-	headers.WriteBearerToken(req, auth.RefreshToken)
 	headers.WriteGatewayVersion(&req.Header, s.config.GitTag, s.config.GitSha)
 	headers.WriteGatewaySecret(&req.Header, s.config.GatewaySecret)
 
-	data, _ := json.Marshal(cookie.Auth{AccessToken: auth.AccessToken})
+	data, _ := json.Marshal(cookie.Auth{RefreshToken: auth.RefreshToken})
 	req.SetBody(data)
 
 	logger.DebugRequest(req, ServiceId)

--- a/service/api/refresh_token_test.go
+++ b/service/api/refresh_token_test.go
@@ -38,8 +38,8 @@ func TestRefreshTokenOk(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("%s%s", endpoint, refreshURI), req.URI().String())
 		assert.Equal(t, string(headers.ContentTypeJson), string(req.Header.ContentType()))
 		assert.Equal(t, string(headers.ContentTypeJson), string(req.Header.Peek(headers.Accept)))
-		assert.Equal(t, fmt.Sprintf("Bearer %s", oldRefreshToken), string(req.Header.Peek(headers.Authorization)))
-		assert.Equal(t, fmt.Sprintf(`{"accessToken":"%s"}`, oldAccessToken), string(req.Body()))
+		assert.Empty(t, req.Header.Peek(headers.Authorization))
+		assert.Equal(t, fmt.Sprintf(`{"refreshToken":"%s"}`, oldRefreshToken), string(req.Body()))
 		assert.Empty(t, req.Header.Peek(headers.XCtGatewayVersion))
 		assert.Empty(t, req.Header.Peek(headers.XCtGatewaySha))
 


### PR DESCRIPTION
## Problem statement

The gateway's internal token refresh call to the backend was non-standard: it sent the refresh token as an `Authorization: Bearer` header and an unused access token in the request body, which doesn't match RFC 6749 (refresh grant belongs in the body, not a header).

Companion API change: cash-track/api#218 (the API now requires and validates a `refreshToken` body field on `/auth/refresh` instead of resolving the token from the header — the two must ship together).

## Changes

- `service/api/refresh_token.go`: the internal refresh request now sends only `{"refreshToken": "<token>"}` in the body, with no `Authorization` header.

## Verification

- `go test -race ./...` (251 tests, 17 packages) — all pass. `go vet ./...` and `golangci-lint run` — clean.
- Two rounds of independent code review, both closed with no material findings.
- Independent live end-to-end verification against the running dev stack: a real transparent token refresh through the actual gateway→API call rotates both cookies and keeps the session valid (reproduced 6/6), confirming the new request body is exactly what the updated API contract expects.
