### PR TITLE
feat(gateway): forward requests to the API's /v1 prefix

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,15 +20,17 @@ info:
     - **Transparent token refresh** — intercepts `401` responses, silently refreshes the token
       pair, and retries the original request
     - **CORS** — validates `Origin` header against the allow-list and sets appropriate response headers
-    - **Path rewriting** — strips the `/api` prefix before forwarding to the backend
+    - **Path rewriting** — strips the `/api` prefix and adds a `/v1` prefix before forwarding
+      to the backend
 
     ## Path Rewriting
 
-    All `/api/*` paths are forwarded to the backend with the `/api` prefix removed:
+    All `/api/*` paths are forwarded to the backend with the `/api` prefix removed and a `/v1`
+    prefix added:
 
     ```
-    Gateway  /api/wallets  →  Backend  /wallets
-    Gateway  /api/auth/login  →  Backend  /auth/login
+    Gateway  /api/wallets  →  Backend  /v1/wallets
+    Gateway  /api/auth/login  →  Backend  /v1/auth/login
     ```
 
     ## Authentication
@@ -206,7 +208,7 @@ paths:
       description: |
         **Gateway-handled.** The request is:
         1. Validated against Google reCAPTCHA v3 (`X-Ct-Captcha-Challenge` header)
-        2. Forwarded to the backend `POST /auth/login`
+        2. Forwarded to the backend `POST /v1/auth/login`
         3. On success: JWT tokens are stored in `cshtrka` / `cshtrkr` cookies and a
            redirect URL pointing to the web app is returned
 
@@ -268,7 +270,7 @@ paths:
       description: |
         **Gateway-handled.** The request is:
         1. Validated against Google reCAPTCHA v3
-        2. Forwarded to the backend `POST /auth/register`
+        2. Forwarded to the backend `POST /v1/auth/register`
         3. On success: auth cookies set, redirect URL returned
 
         See `POST /api/auth/login` for the full flow description.
@@ -440,7 +442,7 @@ paths:
       summary: Initialise WebAuthn login challenge
       description: |
         **Gateway-handled (captcha only).** Verifies the reCAPTCHA challenge then proxies the
-        request to the backend `GET /auth/login/passkey/init` which returns
+        request to the backend `GET /v1/auth/login/passkey/init` which returns
         `PublicKeyCredentialRequestOptions`. The backend response is forwarded as-is.
       tags: [Auth]
       security: []
@@ -489,7 +491,7 @@ paths:
       description: |
         **Gateway-handled.** The flow:
         1. Reads the refresh token from the `cshtrkr` cookie
-        2. Forwards `POST /auth/logout` to the backend with the refresh token in the request body
+        2. Forwards `POST /v1/auth/logout` to the backend with the refresh token in the request body
         3. **Always** clears the `cshtrka` and `cshtrkr` cookies regardless of the backend response
         4. Returns a redirect URL pointing to the marketing website
 
@@ -553,8 +555,8 @@ paths:
       operationId: proxyGet
       summary: Proxy GET request to backend
       description: |
-        Forwards the request to the backend API after stripping the `/api` prefix.
-        If the user is logged in (`cshtrka` cookie present) the gateway attaches
+        Forwards the request to the backend API after stripping the `/api` prefix and
+        adding a `/v1` prefix. If the user is logged in (`cshtrka` cookie present) the gateway attaches
         `Authorization: Bearer <token>` before forwarding.
 
         **Transparent token refresh:** if the backend returns `401` and a refresh token

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -28,7 +28,7 @@ func TestFullForwardRequestWithAuth(t *testing.T) {
 
 		assert.NotNil(t, req)
 		assert.Equal(t, fasthttp.MethodPatch, string(req.Header.Method()))
-		assert.Equal(t, fmt.Sprintf("%s%s", endpoint, "/auth/profile"), req.URI().String())
+		assert.Equal(t, fmt.Sprintf("%s%s", endpoint, "/v1/auth/profile"), req.URI().String())
 		assert.Equal(t, string(headers.ContentTypeJson), string(req.Header.ContentType()))
 		assert.Equal(t, string(headers.ContentTypeJson), string(req.Header.Peek(headers.Accept)))
 		assert.Equal(t, "10.0.0.1", string(req.Header.Peek(headers.XForwardedFor)))

--- a/service/api/refresh_token.go
+++ b/service/api/refresh_token.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cash-track/gateway/traces"
 )
 
-var refreshURI = []byte("/auth/refresh")
+var refreshURI = []byte("/v1/auth/refresh")
 
 func (s *HttpService) refreshToken(
 	auth cookie.Auth,

--- a/service/api/service.go
+++ b/service/api/service.go
@@ -63,7 +63,7 @@ func (s *HttpService) setRequestURI(dest *fasthttp.URI, path []byte) {
 }
 
 func (s *HttpService) copyRequestURI(src, dest *fasthttp.URI) {
-	path := strings.TrimPrefix(string(src.PathOriginal()), "/api")
+	path := "/v1" + strings.TrimPrefix(string(src.PathOriginal()), "/api")
 	s.setRequestURI(dest, []byte(path))
 	dest.SetQueryStringBytes(src.QueryString())
 }

--- a/service/api/service_test.go
+++ b/service/api/service_test.go
@@ -62,5 +62,5 @@ func TestCopyRequestURI(t *testing.T) {
 
 	s.copyRequestURI(&src, &dest)
 
-	assert.Equal(t, "http://api.test.com/users/create%20one?one=two%203", dest.String())
+	assert.Equal(t, "http://api.test.com/v1/users/create%20one?one=two%203", dest.String())
 }


### PR DESCRIPTION
## Problem statement

The backend API's routes are unversioned — any future breaking change to the request/response contract has no way to coexist with old clients. This PR is the gateway half of a direct cutover to a `/v1`-prefixed API surface.

Companion API change: cash-track/api#219 (moves all routes under `/v1` at the Spiral bootloader level, except `/healthcheck` and `/.well-known/jwks.json` which stay unversioned by convention) — the two must ship together. Deploying only one side breaks all traffic: gateway-only breaks every forwarded request (backend doesn't have `/v1` yet); API-only breaks every request (gateway still forwards to unversioned paths).

## Changes

- `service/api/service.go`: `copyRequestURI()` now rewrites `/api/...` to `/v1/...`. This is the single choke point used by every generically forwarded route (login, register, logout, and the catch-all proxy), so no other routing code changed.
- `service/api/refresh_token.go`: the internal refresh-token call target moves from `/auth/refresh` to `/v1/auth/refresh`.
- `docs/openapi.yaml`: path-rewriting documentation (prose, diagram, per-endpoint descriptions) updated to describe the new `/v1` rewrite.
- `service/api/service_test.go`, `service/api/forward_test.go`: expected-path assertions updated to match.

The healthcheck call (`service/api/healthcheck.go`) is deliberately untouched — it targets the unversioned `/healthcheck` path on both sides.

## Verification

- `make test` (`go test -race ./...`, 251 tests, 17 packages) — all pass, 100% coverage on the touched package.
- `go vet ./...` and `golangci-lint run` — clean.
- Two rounds of independent code review; the one finding (a stale doc description on the catch-all proxy endpoint not mentioning the `/v1` rewrite) was fixed and confirmed. Final review closed with no material findings.
- Independent live end-to-end verification against the running dev stack: gateway public-facing surface unaffected, gateway→API forwarding correctly lands on `/v1/...`, old unversioned backend paths return 404, `/healthcheck` and `/.well-known/jwks.json` remain reachable unversioned, and a real token refresh through the gateway rotates both cookies correctly against the new `/v1/auth/refresh` target.