### PR TITLE
fix(gateway): become the sole CORS authority

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,7 +19,9 @@ info:
     - **Captcha verification** — validates Google reCAPTCHA v3 challenge on auth endpoints
     - **Transparent token refresh** — intercepts `401` responses, silently refreshes the token
       pair, and retries the original request
-    - **CORS** — validates `Origin` header against the allow-list and sets appropriate response headers
+    - **CORS** — answers preflight `OPTIONS` requests directly against the
+      `CORS_ALLOWED_ORIGINS` allow-list, and decorates actual requests with the
+      appropriate `Access-Control-*` response headers
     - **Path rewriting** — strips the `/api` prefix before forwarding to the backend
 
     ## Path Rewriting
@@ -731,66 +733,53 @@ paths:
       operationId: proxyOptions
       summary: CORS preflight
       description: |
-        Handles CORS preflight requests. CSRF validation is bypassed for OPTIONS.
+        The gateway answers a genuine preflight request directly — routing, CSRF, captcha
+        and the backend API are not invoked. A request is a genuine preflight when it is
+        `OPTIONS` **and** carries `Access-Control-Request-Method`; an `OPTIONS` request
+        without that header is not a preflight and is forwarded to the backend like any
+        other request (see `GET`/`POST`/etc. on this path).
 
-        The gateway does **not** answer the preflight by itself: `OPTIONS` is an allowed proxy
-        method, so the request is forwarded to the backend API first and the backend's response
-        is what the client receives. The CORS layer then runs afterwards and, **only if the
-        `Origin` is in `CORS_ALLOWED_ORIGINS`**, adds the `Access-Control-*` headers and
-        overwrites the status with `200` — whatever the backend actually returned.
+        Always responds `204` with an empty body, decided purely by whether `Origin` is in
+        `CORS_ALLOWED_ORIGINS`:
 
-        The practical consequences:
-
-        - Allowed origin → always `200`, regardless of the backend's status. The backend's
-          response headers (including `X-Ct-Api-Version` / `X-Ct-Api-Sha`) are still relayed.
-        - Disallowed or missing origin → no `Access-Control-*` headers and no status override,
-          so the backend's status and body pass through unchanged.
-        - Backend unreachable → `502`, before the CORS layer has anything to overwrite.
+        - Allowed origin → `204` with the full CORS header set below, including
+          `Access-Control-Allow-Headers` reflecting whatever the browser sent in
+          `Access-Control-Request-Headers` (dynamic reflection, not a fixed list).
+        - Disallowed or missing origin → `204` with none of the `Access-Control-*` headers
+          and no `Vary`.
       tags: [Proxy]
       security: []
       responses:
-        "200":
+        "204":
           description: |
-            Preflight accepted. Note this status is imposed by the CORS layer for an allowed
-            origin and does not imply the backend returned `200`.
+            Preflight answered directly by the gateway. Header set below is present only
+            when `Origin` is in `CORS_ALLOWED_ORIGINS`; otherwise the response carries none
+            of them.
           headers:
             Access-Control-Allow-Origin:
               schema:
                 type: string
+            Vary:
+              description: "`Origin`, then `Access-Control-Request-Headers` appended."
+              schema:
+                type: string
+                example: "Origin, Access-Control-Request-Headers"
+            Access-Control-Allow-Credentials:
+              schema:
+                type: string
+                example: "true"
             Access-Control-Allow-Methods:
               schema:
                 type: string
                 example: "GET,POST,PUT,PATCH,DELETE,OPTIONS"
             Access-Control-Allow-Headers:
+              description: Echoes the request's `Access-Control-Request-Headers` value verbatim.
               schema:
                 type: string
-                example: "Content-Type,X-Ct-Captcha-Challenge,*"
-            Access-Control-Allow-Credentials:
+            Access-Control-Max-Age:
               schema:
                 type: string
-                example: "true"
-            X-Ct-Gateway-Version:
-              $ref: "#/components/headers/GatewayVersion"
-            X-Ct-Gateway-Sha:
-              $ref: "#/components/headers/GatewaySha"
-            X-Ct-Api-Version:
-              $ref: "#/components/headers/ApiVersion"
-            X-Ct-Api-Sha:
-              $ref: "#/components/headers/ApiSha"
-            Strict-Transport-Security:
-              $ref: "#/components/headers/StrictTransportSecurity"
-            X-Content-Type-Options:
-              $ref: "#/components/headers/XContentTypeOptions"
-            X-Frame-Options:
-              $ref: "#/components/headers/XFrameOptions"
-            Referrer-Policy:
-              $ref: "#/components/headers/ReferrerPolicy"
-            Content-Security-Policy:
-              $ref: "#/components/headers/ContentSecurityPolicy"
-        "502":
-          $ref: "#/components/responses/BadGateway"
-        "503":
-          $ref: "#/components/responses/ServiceUnavailable"
+                example: "600"
 
 # =============================================================================
 # COMPONENTS
@@ -1050,12 +1039,23 @@ components:
         X-Ct-Api-Sha:
           $ref: "#/components/headers/ApiSha"
         Access-Control-Allow-Origin:
+          description: Present only when the request's `Origin` is in `CORS_ALLOWED_ORIGINS`.
           schema:
             type: string
+        Vary:
+          description: "`Origin`, present alongside Access-Control-Allow-Origin."
+          schema:
+            type: string
+            example: "Origin"
         Access-Control-Allow-Credentials:
           schema:
             type: string
             example: "true"
+        Access-Control-Expose-Headers:
+          description: Fixed list, set by the gateway whenever Access-Control-Allow-Origin is present.
+          schema:
+            type: string
+            example: "X-Ct-Trace-Id,X-Ct-Gateway-Version,X-Ct-Gateway-Sha,X-Ct-Api-Version,X-Ct-Api-Sha"
         Strict-Transport-Security:
           $ref: "#/components/headers/StrictTransportSecurity"
         X-Content-Type-Options:

--- a/headers/cors.go
+++ b/headers/cors.go
@@ -10,6 +10,10 @@ import (
 	"github.com/cash-track/gateway/config"
 )
 
+// corsMaxAge is the Access-Control-Max-Age value (seconds) advertised on preflight
+// responses.
+const corsMaxAge = "600"
+
 var (
 	CorsAllowedMethods = []string{
 		fasthttp.MethodGet,
@@ -18,11 +22,6 @@ var (
 		fasthttp.MethodPatch,
 		fasthttp.MethodDelete,
 		fasthttp.MethodOptions,
-	}
-	CorsAllowedHeaders = []string{
-		ContentType,
-		XCtCaptchaChallenge,
-		"*",
 	}
 	CorsExposedHeaders = []string{
 		XCtTraceId,
@@ -45,50 +44,107 @@ func isHealthPath(ctx *fasthttp.RequestCtx) bool {
 	return healthPaths[string(ctx.Request.URI().PathOriginal())]
 }
 
-// CorsHandler is a middleware to write default CORS headers if no forwarded.
+// isPreflightRequest reports whether ctx is a genuine CORS preflight request per the
+// Fetch spec: an OPTIONS request carrying Access-Control-Request-Method. An OPTIONS
+// request without that header is not a preflight and must be treated like any other request.
+func isPreflightRequest(ctx *fasthttp.RequestCtx) bool {
+	return string(ctx.Request.Header.Method()) == fasthttp.MethodOptions &&
+		len(ctx.Request.Header.Peek(AccessControlRequestMethod)) > 0
+}
+
+// CorsHandler answers a genuine preflight request directly — routing/csrf/captcha/
+// forwarding never see it. Any other request is handled normally and then decorated
+// with CORS response headers.
 func CorsHandler(h fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(ctx *fasthttp.RequestCtx) {
+		if !isHealthPath(ctx) && isPreflightRequest(ctx) {
+			writePreflightResponse(ctx)
+
+			return
+		}
+
 		h(ctx)
 
-		if validateCorsOrigin(ctx) {
-			writeCorsAllowedHeaders(ctx)
+		if isAllowedOrigin(ctx) {
+			writeActualCorsHeaders(ctx)
 		}
 	}
 }
 
-func validateCorsOrigin(ctx *fasthttp.RequestCtx) bool {
+// writePreflightResponse answers a preflight request directly, without invoking the
+// inner handler. Always responds 204. Origin allowed: full CORS header set, dynamically
+// reflecting Access-Control-Request-Headers. Origin not allowed: same 204, no CORS headers.
+func writePreflightResponse(ctx *fasthttp.RequestCtx) {
+	ctx.Response.SetStatusCode(fasthttp.StatusNoContent)
+
+	origin := requestOrigin(ctx)
+	allowed := config.Global.CorsAllowedOrigins[origin]
+
+	debugCorsOrigin(ctx, "preflight", origin, allowed)
+
+	if !allowed {
+		return
+	}
+
+	ctx.Response.Header.SetBytesV(AccessControlAllowOrigin, []byte(origin))
+	addVary(&ctx.Response.Header, Origin)
+	ctx.Response.Header.Set(AccessControlAllowCredentials, "true")
+	ctx.Response.Header.Set(AccessControlAllowMethods, strings.Join(CorsAllowedMethods, ","))
+	ctx.Response.Header.SetBytesV(AccessControlAllowHeaders, ctx.Request.Header.Peek(AccessControlRequestHeaders))
+	addVary(&ctx.Response.Header, AccessControlRequestHeaders)
+	ctx.Response.Header.Set(AccessControlMaxAge, corsMaxAge)
+}
+
+// isAllowedOrigin reports whether ctx is eligible for CORS decoration: not a health
+// path, and its Origin header is in the allow-list.
+func isAllowedOrigin(ctx *fasthttp.RequestCtx) bool {
 	if isHealthPath(ctx) {
 		return false
 	}
 
-	clientIp := GetClientIPFromContext(ctx)
-	if val := ctx.Response.Header.Peek(AccessControlAllowOrigin); val != nil {
-		// CORS headers were already configured by upstream
-		if config.Global.DebugHttp {
-			slog.Debug("CORS validation for origin by upstream", "client_ip", clientIp, "origin", string(val))
-		}
+	origin := requestOrigin(ctx)
+	allowed := config.Global.CorsAllowedOrigins[origin]
 
-		return false
-	}
+	debugCorsOrigin(ctx, "actual", origin, allowed)
 
-	origin := strings.ToLower(string(ctx.Request.Header.Peek(Origin)))
-	_, ok := config.Global.CorsAllowedOrigins[origin]
-
-	if config.Global.DebugHttp {
-		slog.Debug("CORS validation for origin by gateway", "client_ip", clientIp, "origin", origin, "allowed", ok)
-	}
-
-	return ok
+	return allowed
 }
 
-func writeCorsAllowedHeaders(ctx *fasthttp.RequestCtx) {
-	ctx.Response.Header.SetBytesV(AccessControlAllowOrigin, bytes.ToLower(ctx.Request.Header.Peek(Origin)))
-	ctx.Response.Header.Set(AccessControlAllowMethods, strings.Join(CorsAllowedMethods, ","))
-	ctx.Response.Header.Set(AccessControlAllowHeaders, strings.Join(CorsAllowedHeaders, ","))
+// writeActualCorsHeaders decorates an actual (non-preflight) response for an allowed
+// origin: Allow-Origin, Vary, Allow-Credentials and the exposed-header list.
+// Allow-Methods/Allow-Headers/Max-Age are preflight-only and not set here.
+func writeActualCorsHeaders(ctx *fasthttp.RequestCtx) {
+	ctx.Response.Header.SetBytesV(AccessControlAllowOrigin, []byte(requestOrigin(ctx)))
+	addVary(&ctx.Response.Header, Origin)
 	ctx.Response.Header.Set(AccessControlAllowCredentials, "true")
 	ctx.Response.Header.Set(AccessControlExposeHeaders, strings.Join(CorsExposedHeaders, ","))
+}
 
-	if string(ctx.Request.Header.Method()) == fasthttp.MethodOptions {
-		ctx.Response.Header.SetStatusCode(fasthttp.StatusOK)
+func requestOrigin(ctx *fasthttp.RequestCtx) string {
+	return strings.ToLower(string(ctx.Request.Header.Peek(Origin)))
+}
+
+func debugCorsOrigin(ctx *fasthttp.RequestCtx, stage, origin string, allowed bool) {
+	if !config.Global.DebugHttp {
+		return
+	}
+
+	slog.Debug("CORS validation for origin by gateway",
+		"stage", stage, "client_ip", GetClientIPFromContext(ctx), "origin", origin, "allowed", allowed)
+}
+
+// addVary appends value to the Vary header if not already present, following HTTP's
+// comma-separated multi-value convention (mirrors fasthttp's own unexported
+// addVaryBytes helper, used internally for Accept-Encoding).
+func addVary(header *fasthttp.ResponseHeader, value string) {
+	current := header.Peek(Vary)
+	if len(current) == 0 {
+		header.Set(Vary, value)
+
+		return
+	}
+
+	if !bytes.Contains(current, []byte(value)) {
+		header.SetBytesV(Vary, append(append(bytes.Clone(current), ", "...), value...))
 	}
 }

--- a/headers/cors_test.go
+++ b/headers/cors_test.go
@@ -9,97 +9,225 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-func TestCorsHandler(t *testing.T) {
+// spyHandler records whether/how many times the inner handler was invoked, so tests can
+// assert a short-circuited preflight never reaches routing/csrf/captcha/forwarding.
+func spyHandler() (fasthttp.RequestHandler, *int) {
+	calls := 0
+
+	return func(ctx *fasthttp.RequestCtx) {
+		calls++
+	}, &calls
+}
+
+func TestCorsHandlerPreflightAllowedOrigin(t *testing.T) {
 	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
 	config.Global.DebugHttp = true
 
-	t.Run("Allow", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(Origin, "Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(AccessControlRequestMethod, fasthttp.MethodPut)
+	ctx.Request.Header.Set(AccessControlRequestHeaders, "X-Custom-Header, Content-Type")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
 
-		assert.Equal(t, "true", string(ctx.Response.Header.Peek(AccessControlAllowCredentials)))
-		assert.Equal(t, strings.Join(CorsAllowedMethods, ","), string(ctx.Response.Header.Peek(AccessControlAllowMethods)))
-		assert.Equal(t, strings.Join(CorsAllowedHeaders, ","), string(ctx.Response.Header.Peek(AccessControlAllowHeaders)))
-		assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
-		assert.Equal(t, strings.Join(CorsExposedHeaders, ","), string(ctx.Response.Header.Peek(AccessControlExposeHeaders)))
-	})
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+	assert.Equal(t, "true", string(ctx.Response.Header.Peek(AccessControlAllowCredentials)))
+	assert.Equal(t, strings.Join(CorsAllowedMethods, ","), string(ctx.Response.Header.Peek(AccessControlAllowMethods)))
+	assert.Equal(t, "X-Custom-Header, Content-Type", string(ctx.Response.Header.Peek(AccessControlAllowHeaders)))
+	assert.Equal(t, "600", string(ctx.Response.Header.Peek(AccessControlMaxAge)))
+	assert.Equal(t, "Origin, Access-Control-Request-Headers", string(ctx.Response.Header.Peek(Vary)))
+	assert.Equal(t, 0, *calls, "inner handler must not be invoked for a true preflight request")
+}
 
-	t.Run("AllowOptionsStatusAlwaysOk", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
-		ctx.Request.Header.Set(Origin, "Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+func TestCorsHandlerPreflightDisallowedOrigin(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+	ctx.Request.Header.Set(Origin, "evil.com")
+	ctx.Request.Header.Set(AccessControlRequestMethod, fasthttp.MethodPut)
+	ctx.Request.Header.Set(AccessControlRequestHeaders, "X-Custom-Header")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
 
-		assert.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
-	})
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
 
-	t.Run("RejectIgnorePath", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(Origin, "a.Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
-		ctx.Request.URI().SetPath("/live")
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlMaxAge))
+	assert.Empty(t, ctx.Response.Header.Peek(Vary))
+	assert.Equal(t, 0, *calls, "inner handler must not be invoked for a true preflight request")
+}
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+func TestCorsHandlerDebugHttpDisabledSkipsLogging(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	orig := config.Global.DebugHttp
+	config.Global.DebugHttp = false
+	defer func() { config.Global.DebugHttp = orig }()
 
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
-	})
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(Origin, "Test.Com")
 
-	t.Run("RejectNotAllowed", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(Origin, "a.Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+	assert.Equal(t, 1, *calls)
+}
 
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
-	})
+func TestCorsHandlerActualRequestAllowedOrigin(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
 
-	// /%6Cive decodes to /live, but fasthttp/router dispatches on the raw,
-	// undecoded path and would 404 this request. isHealthPath must agree with the
-	// router and not treat the encoded lookalike as the real health probe.
-	t.Run("DoesNotIgnorePercentEncodedLookalike", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(Origin, "Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
-		ctx.Request.URI().SetPath("/%6Cive")
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
 
-		assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
-	})
+	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+	assert.Equal(t, "true", string(ctx.Response.Header.Peek(AccessControlAllowCredentials)))
+	assert.Equal(t, "Origin", string(ctx.Response.Header.Peek(Vary)))
+	assert.Equal(t, strings.Join(CorsExposedHeaders, ","), string(ctx.Response.Header.Peek(AccessControlExposeHeaders)))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlMaxAge))
+	assert.Equal(t, 1, *calls, "inner handler must be invoked for an actual request")
+}
 
-	t.Run("RejectAllowedByUpstream", func(t *testing.T) {
-		ctx := fasthttp.RequestCtx{}
-		ctx.Request.Header.Set(Origin, "Test.Com")
-		ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
-		ctx.Response.Header.Set(AccessControlAllowOrigin, "test.com")
+func TestCorsHandlerActualRequestDisallowedOrigin(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
 
-		handler := CorsHandler(func(ctx *fasthttp.RequestCtx) {})
-		handler(&ctx)
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(Origin, "a.Test.Com")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
 
-		assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
-		assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
-	})
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
 
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(Vary))
+	assert.Equal(t, 1, *calls, "request must still be processed normally without an allowed origin")
+}
+
+func TestCorsHandlerActualRequestMissingOrigin(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
+	assert.Equal(t, 1, *calls)
+}
+
+func TestCorsHandlerHealthPathIgnoresPreflight(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(AccessControlRequestMethod, fasthttp.MethodGet)
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+	ctx.Request.URI().SetPath("/live")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.NotEqual(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlMaxAge))
+	assert.Equal(t, 1, *calls, "health paths must fall through to the inner handler, never short-circuited")
+}
+
+func TestCorsHandlerHealthPathIgnoresActualRequest(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(Origin, "a.Test.Com")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+	ctx.Request.URI().SetPath("/live")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowCredentials))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlExposeHeaders))
+	assert.Equal(t, 1, *calls)
+}
+
+// /%6Cive decodes to /live, but fasthttp/router dispatches on the raw, undecoded path
+// and would 404 this request. isHealthPath must agree with the router and not treat the
+// encoded lookalike as the real health probe.
+func TestCorsHandlerDoesNotIgnorePercentEncodedLookalike(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+	ctx.Request.URI().SetPath("/%6Cive")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+	assert.Equal(t, 1, *calls)
+}
+
+// An OPTIONS request without Access-Control-Request-Method is not a genuine preflight —
+// it must not be short-circuited and instead falls through like any other request.
+func TestCorsHandlerOptionsWithoutRequestMethodIsNotPreflight(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.NotEqual(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(AccessControlAllowOrigin)))
+	assert.Equal(t, "true", string(ctx.Response.Header.Peek(AccessControlAllowCredentials)))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(AccessControlMaxAge))
+	assert.Equal(t, 1, *calls, "an OPTIONS request without Access-Control-Request-Method must fall through")
 }

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/valyala/fasthttp"
@@ -190,28 +189,20 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 	return forwardResponse(ctx, resp)
 }
 
+// forwardResponse relays the backend's status, body and headers to the client.
+// CORS response headers are set by headers.CorsHandler, which wraps this call.
 func forwardResponse(ctx *fasthttp.RequestCtx, resp *fasthttp.Response) error {
 	ctx.SetStatusCode(resp.StatusCode())
 	ctx.SetBody(bytes.Clone(resp.Body()))
 
 	headers.CopyFromResponse(resp, ctx, []string{
-		headers.AccessControlAllowOrigin,
-		headers.AccessControlAllowMethods,
-		headers.AccessControlAllowHeaders,
-		headers.AccessControlMaxAge,
 		headers.ContentType,
 		headers.RetryAfter,
-		headers.Vary,
 		headers.XCtApiSha,
 		headers.XCtApiVersion,
 		headers.XRateLimit,
 		headers.XRateLimitRemaining,
 	})
-
-	if val := ctx.Response.Header.Peek(headers.AccessControlAllowOrigin); val != nil {
-		ctx.Response.Header.Set(headers.AccessControlAllowCredentials, "true")
-		ctx.Response.Header.Set(headers.AccessControlExposeHeaders, strings.Join(headers.CorsExposedHeaders, ","))
-	}
 
 	return nil
 }

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -692,13 +691,8 @@ func TestForwardResponse(t *testing.T) {
 	resp := fasthttp.Response{}
 	resp.SetStatusCode(fasthttp.StatusUnauthorized)
 	resp.SetBody([]byte("not allowed\n\r"))
-	resp.Header.Set(headers.AccessControlAllowOrigin, "test.com")
-	resp.Header.Set(headers.AccessControlMaxAge, "3600")
-	resp.Header.Set(headers.AccessControlAllowMethods, "GET,POST")
-	resp.Header.Set(headers.AccessControlAllowHeaders, "Content-Type,Accept-Language")
 	resp.Header.Set(headers.ContentType, "text/plain")
 	resp.Header.Set(headers.RetryAfter, "200")
-	resp.Header.Set(headers.Vary, "Content-Type,X-Rate-Limit")
 	resp.Header.Set(headers.XCtApiVersion, "v9.9.9")
 	resp.Header.Set(headers.XCtApiSha, "deadbeef")
 	resp.Header.Set(headers.XRateLimit, "123")
@@ -708,30 +702,37 @@ func TestForwardResponse(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	assert.Equal(t, "test.com", string(ctx.Response.Header.Peek(headers.AccessControlAllowOrigin)))
-	assert.Equal(t, "true", string(ctx.Response.Header.Peek(headers.AccessControlAllowCredentials)))
-	assert.Equal(t, strings.Join(headers.CorsExposedHeaders, ","), string(ctx.Response.Header.Peek(headers.AccessControlExposeHeaders)))
-	assert.Equal(t, "GET,POST", string(ctx.Response.Header.Peek(headers.AccessControlAllowMethods)))
-	assert.Equal(t, "Content-Type,Accept-Language", string(ctx.Response.Header.Peek(headers.AccessControlAllowHeaders)))
-	assert.Equal(t, "3600", string(ctx.Response.Header.Peek(headers.AccessControlMaxAge)))
 	assert.Equal(t, "text/plain", string(ctx.Response.Header.Peek(headers.ContentType)))
 	assert.Equal(t, "200", string(ctx.Response.Header.Peek(headers.RetryAfter)))
-	assert.Equal(t, "Content-Type,X-Rate-Limit", string(ctx.Response.Header.Peek(headers.Vary)))
 	assert.Equal(t, "v9.9.9", string(ctx.Response.Header.Peek(headers.XCtApiVersion)))
 	assert.Equal(t, "deadbeef", string(ctx.Response.Header.Peek(headers.XCtApiSha)))
 	assert.Equal(t, "123", string(ctx.Response.Header.Peek(headers.XRateLimit)))
 	assert.Equal(t, "2", string(ctx.Response.Header.Peek(headers.XRateLimitRemaining)))
 }
 
-func TestForwardResponseWithoutOriginSkipsCorsHeaders(t *testing.T) {
+// CORS response headers are decided entirely by headers.CorsHandler, which wraps
+// forwardResponse's caller. The PHP API never sends Access-Control-*/Vary anymore, but
+// even if a backend response somehow contained them, forwardResponse must not relay
+// them — there must be exactly one place deciding CORS response headers.
+func TestForwardResponseDoesNotRelayCorsHeadersFromBackend(t *testing.T) {
 	ctx := fasthttp.RequestCtx{}
 
 	resp := fasthttp.Response{}
 	resp.SetStatusCode(fasthttp.StatusOK)
+	resp.Header.Set(headers.AccessControlAllowOrigin, "test.com")
+	resp.Header.Set(headers.AccessControlAllowMethods, "GET,POST")
+	resp.Header.Set(headers.AccessControlAllowHeaders, "Content-Type,Accept-Language")
+	resp.Header.Set(headers.AccessControlMaxAge, "3600")
+	resp.Header.Set(headers.Vary, "Content-Type,X-Rate-Limit")
 
 	err := forwardResponse(&ctx, &resp)
 
 	assert.NoError(t, err)
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowOrigin))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowMethods))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowHeaders))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlMaxAge))
+	assert.Empty(t, ctx.Response.Header.Peek(headers.Vary))
 	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlAllowCredentials))
 	assert.Empty(t, ctx.Response.Header.Peek(headers.AccessControlExposeHeaders))
 }


### PR DESCRIPTION
## Problem statement

The gateway's existing CORS handler was a passthrough, not an authority: `OPTIONS` preflight requests matched the router's wild-method registration and were forwarded through the full handler chain (csrf, captcha, forwarding) to the backend API, which answered them. The gateway's CORS code only ever decorated whatever came back — it never made the allow/deny decision itself in production.

Companion changes, must ship together: cash-track/api#220 (deletes the API's now-redundant CORS code — once this lands, the API can no longer answer preflight at all), cash-track/infra#TBD (drops the unused `CORS_ALLOWED_ORIGINS` from the API's env template; the gateway's own copy is unchanged).

## Changes

- `headers/cors.go`: genuine preflight (`OPTIONS` + `Access-Control-Request-Method`) is now intercepted and answered directly, before routing/csrf/captcha/forwarding run — the backend is never contacted. Actual requests are decorated with CORS headers after the inner handler completes, as before.
- `Access-Control-Allow-Headers` now dynamically reflects the request's `Access-Control-Request-Headers` instead of a hardcoded, spec-incorrect list (a literal `*` mixed into a header list isn't a wildcard, and is ignored anyway once credentials are involved).
- `Access-Control-Max-Age: 600` is now sent on preflight responses (previously missing).
- `service/api/forward.go`: no longer relays or duplicates `Access-Control-*`/`Vary` headers from the backend response.
- `docs/openapi.yaml` updated to document the preflight endpoint as answered locally (`204`, backend unreachable) instead of proxied.

## Verification

- `go test -race ./...` — 254 tests, 17 packages, all pass. `go vet` and `golangci-lint run` — clean. 100% statement coverage on the touched packages.
- `docs/openapi.yaml` — valid, same pre-existing warning count as baseline.
- Independent code review — no material findings.
- Live end-to-end verification against the running dev stack, together with the api change: curl-based preflight simulation for both allowed and disallowed origins, confirmed via RoadRunner's own request-count metric that preflight never reaches the backend, direct-to-API `OPTIONS` now 404s with no CORS headers, and a real browser flow — registered a new account and completed a genuine cross-origin credentialed login through the gateway between two different subdomains, with correct per-origin header echoing on real API calls.
