### PR TITLE
fix(gateway): stop replaying mutating requests; register passkey init on GET

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -439,7 +439,7 @@ paths:
           $ref: "#/components/responses/ServiceUnavailable"
 
   /api/auth/login/passkey/init:
-    post:
+    get:
       operationId: authPasskeyLoginInit
       summary: Initialise WebAuthn login challenge
       description: |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -220,6 +220,7 @@ paths:
       security: []
       parameters:
         - $ref: "#/components/parameters/CaptchaHeader"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: true
         content:
@@ -280,6 +281,7 @@ paths:
       security: []
       parameters:
         - $ref: "#/components/parameters/CaptchaHeader"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: true
         content:
@@ -336,6 +338,7 @@ paths:
       security: []
       parameters:
         - $ref: "#/components/parameters/CaptchaHeader"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: true
         content:
@@ -395,6 +398,7 @@ paths:
       security: []
       parameters:
         - $ref: "#/components/parameters/CaptchaHeader"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: true
         content:
@@ -504,6 +508,8 @@ paths:
       security:
         - cookieAuth: []
         - {}
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       responses:
         "200":
           description: |
@@ -602,6 +608,7 @@ paths:
         - {}
       parameters:
         - $ref: "#/components/parameters/CsrfCookie"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: false
         content:
@@ -642,6 +649,7 @@ paths:
         - {}
       parameters:
         - $ref: "#/components/parameters/CsrfCookie"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: false
         content:
@@ -678,6 +686,7 @@ paths:
         - {}
       parameters:
         - $ref: "#/components/parameters/CsrfCookie"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       requestBody:
         required: false
         content:
@@ -714,6 +723,7 @@ paths:
         - {}
       parameters:
         - $ref: "#/components/parameters/CsrfCookie"
+        - $ref: "#/components/parameters/IdempotencyKeyHeader"
       responses:
         "200":
           $ref: "#/components/responses/ProxySuccess"
@@ -828,6 +838,20 @@ components:
         type: string
         format: uuid
 
+    IdempotencyKeyHeader:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Canonical lowercase UUIDv4, generated client-side, uniquely identifying this mutating
+        request. Forwarded unchanged to the backend, which is the authoritative source of
+        deduplication: a repeated request with the same key (e.g. from a gateway/Traefik retry)
+        is deduplicated by the backend rather than applied twice. The gateway itself does not
+        interpret the value — it only relays it, including across an internal 401-refresh-retry.
+      schema:
+        type: string
+        format: uuid
+
   # ---------------------------------------------------------------------------
   # HEADERS
   # ---------------------------------------------------------------------------
@@ -886,6 +910,17 @@ components:
       schema:
         type: string
         example: "9f8e7d6c5b4a"
+
+    IdempotencyReplayed:
+      description: |
+        Set by the backend, not the gateway — the gateway only relays it unchanged. Present
+        (`true`) when the response was served from the backend's idempotency store for a
+        previously-seen `Idempotency-Key` rather than freshly processed. Diagnostic only, not
+        required for correct client behavior. Absent when the request carried no
+        `Idempotency-Key` or was processed fresh.
+      schema:
+        type: string
+        example: "true"
 
     StrictTransportSecurity:
       description: |
@@ -1040,6 +1075,8 @@ components:
           $ref: "#/components/headers/ApiVersion"
         X-Ct-Api-Sha:
           $ref: "#/components/headers/ApiSha"
+        Idempotency-Replayed:
+          $ref: "#/components/headers/IdempotencyReplayed"
         Access-Control-Allow-Origin:
           description: Present only when the request's `Origin` is in `CORS_ALLOWED_ORIGINS`.
           schema:

--- a/headers/cors_test.go
+++ b/headers/cors_test.go
@@ -44,6 +44,29 @@ func TestCorsHandlerPreflightAllowedOrigin(t *testing.T) {
 	assert.Equal(t, 0, *calls, "inner handler must not be invoked for a true preflight request")
 }
 
+// Idempotency-Key is a non-simple header sent on every mutating request: preflight must
+// reflect it back or the browser blocks the request. Allow-Headers is built from what the
+// browser asked for, so no fixed allow-list names it.
+func TestCorsHandlerPreflightAllowsIdempotencyKeyHeader(t *testing.T) {
+	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
+	config.Global.DebugHttp = true
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+	ctx.Request.Header.Set(Origin, "Test.Com")
+	ctx.Request.Header.Set(AccessControlRequestMethod, fasthttp.MethodPost)
+	ctx.Request.Header.Set(AccessControlRequestHeaders, "Idempotency-Key, Content-Type")
+	ctx.Request.Header.Set(XForwardedFor, "127.0.0.1")
+
+	inner, calls := spyHandler()
+	handler := CorsHandler(inner)
+	handler(&ctx)
+
+	assert.Equal(t, fasthttp.StatusNoContent, ctx.Response.StatusCode())
+	assert.Equal(t, "Idempotency-Key, Content-Type", string(ctx.Response.Header.Peek(AccessControlAllowHeaders)))
+	assert.Equal(t, 0, *calls, "inner handler must not be invoked for a true preflight request")
+}
+
 func TestCorsHandlerPreflightDisallowedOrigin(t *testing.T) {
 	config.Global.CorsAllowedOrigins = map[string]bool{"test.com": true}
 	config.Global.DebugHttp = true

--- a/headers/headers.go
+++ b/headers/headers.go
@@ -22,6 +22,8 @@ const (
 	CfConnectingIP                = "Cf-Connecting-IP"
 	ContentSecurityPolicy         = "Content-Security-Policy"
 	ContentType                   = "Content-Type"
+	IdempotencyKey                = "Idempotency-Key"
+	IdempotencyReplayed           = "Idempotency-Replayed"
 	Origin                        = "Origin"
 	Referer                       = "Referer"
 	ReferrerPolicy                = "Referrer-Policy"
@@ -54,6 +56,8 @@ var (
 	singleInstanceHeaders = map[string]bool{
 		strings.ToLower(Authorization):       true,
 		strings.ToLower(ContentType):         true,
+		strings.ToLower(IdempotencyKey):      true,
+		strings.ToLower(IdempotencyReplayed): true,
 		strings.ToLower(Origin):              true,
 		strings.ToLower(Referer):             true,
 		strings.ToLower(RetryAfter):          true,

--- a/http/client.go
+++ b/http/client.go
@@ -34,6 +34,22 @@ func NewFastHttpClient() Client {
 			NoDefaultUserAgentHeader:      true,
 			DisableHeaderNamesNormalizing: true,
 			DisablePathNormalizing:        true,
+			// No retries at this layer. fasthttp's defaults (5 attempts, PUT counted as
+			// idempotent) blindly replay a mutating request whose write failed after the
+			// backend already committed it.
+			//
+			// Do not raise above 1: fasthttp retries any method on io.EOF regardless of
+			// RetryIf, so only this value closes that hole. GET/HEAD lose retries here as
+			// a result — retryhttp one layer up still covers them. Pinned by
+			// TestDoNotRetriedAtThisLayerRegardlessOfMethod.
+			MaxIdemponentCallAttempts: 1,
+			// Unreachable at MaxIdemponentCallAttempts = 1; kept as a statement of intent.
+			// PUT is excluded despite being RFC-idempotent: the gateway's PUT routes are
+			// read-modify-write, and a write error can't distinguish "never arrived" from
+			// "committed, then the connection died".
+			RetryIf: func(req *fasthttp.Request) bool {
+				return req.Header.IsGet() || req.Header.IsHead()
+			},
 			Dial: (&fasthttp.TCPDialer{
 				Concurrency:      Concurrency,
 				DNSCacheDuration: time.Hour,

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -1,6 +1,10 @@
 package http
 
 import (
+	"bufio"
+	"net"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,6 +15,149 @@ import (
 func TestNewFastHttpClient(t *testing.T) {
 	client := NewFastHttpClient()
 	assert.NotNil(t, client)
+
+	fhc, ok := client.(*FastHttpClient)
+	assert.True(t, ok)
+	assert.Equal(t, 1, fhc.MaxIdemponentCallAttempts)
+	assert.NotNil(t, fhc.RetryIf)
+}
+
+// Tests the RetryIf predicate in isolation; it cannot catch MaxIdemponentCallAttempts
+// being raised above 1 (see io.EOF in client.go). That is covered end-to-end by
+// TestDoNotRetriedAtThisLayerRegardlessOfMethod below.
+func TestNewFastHttpClientRetryIf(t *testing.T) {
+	client := NewFastHttpClient().(*FastHttpClient)
+
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{fasthttp.MethodGet, true},
+		{fasthttp.MethodHead, true},
+		{fasthttp.MethodPost, false},
+		{fasthttp.MethodPut, false},
+		{fasthttp.MethodPatch, false},
+		{fasthttp.MethodDelete, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := &fasthttp.Request{}
+			req.Header.SetMethod(tt.method)
+
+			assert.Equal(t, tt.want, client.RetryIf(req))
+		})
+	}
+}
+
+// readFullRequest reads headers plus any Content-Length body, reporting whether a full
+// request arrived.
+func readFullRequest(c net.Conn) bool {
+	br := bufio.NewReader(c)
+	contentLength := 0
+
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			for _, ch := range strings.TrimSpace(line[len("content-length:"):]) {
+				if ch >= '0' && ch <= '9' {
+					contentLength = contentLength*10 + int(ch-'0')
+				}
+			}
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+
+	if contentLength == 0 {
+		return true
+	}
+
+	body := make([]byte, contentLength)
+	for read := 0; read < contentLength; {
+		n, err := br.Read(body[read:])
+		if err != nil {
+			return false
+		}
+		read += n
+	}
+
+	return true
+}
+
+// silentCloseBackend accepts one connection, fully reads the request, then closes without
+// responding — the io.EOF case. Returns the listener and a delivered-request counter.
+func silentCloseBackend(t *testing.T) (net.Listener, *int64) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var delivered int64
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				if readFullRequest(c) {
+					atomic.AddInt64(&delivered, 1)
+				}
+			}(c)
+		}
+	}()
+
+	return ln, &delivered
+}
+
+// Regression test for MaxIdemponentCallAttempts: drives the real client against a backend
+// that reads each request then closes silently. Every method must be delivered exactly
+// once; raising the attempt count above 1 makes this observe delivered > 1.
+func TestDoNotRetriedAtThisLayerRegardlessOfMethod(t *testing.T) {
+	methods := []string{
+		fasthttp.MethodGet,
+		fasthttp.MethodHead,
+		fasthttp.MethodPost,
+		fasthttp.MethodPut,
+		fasthttp.MethodPatch,
+		fasthttp.MethodDelete,
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			ln, delivered := silentCloseBackend(t)
+			defer func() { _ = ln.Close() }()
+
+			client := NewFastHttpClient()
+			client.WithReadTimeout(2 * time.Second)
+			client.WithWriteTimeout(2 * time.Second)
+
+			req := fasthttp.AcquireRequest()
+			defer fasthttp.ReleaseRequest(req)
+			resp := fasthttp.AcquireResponse()
+			defer fasthttp.ReleaseResponse(resp)
+
+			req.Header.SetMethod(method)
+			req.SetRequestURI("http://" + ln.Addr().String() + "/v1/wallets/1/charges")
+			req.Header.SetContentType("application/json")
+			req.SetBody([]byte(`{"type":"-","amount":100,"title":"coffee"}`))
+
+			err := client.Do(req, resp)
+
+			assert.Error(t, err)
+			assert.EqualValues(t, 1, atomic.LoadInt64(delivered),
+				"%s must be delivered to the backend exactly once at this layer, "+
+					"regardless of RetryIf — MaxIdemponentCallAttempts must stay at 1", method)
+		})
+	}
 }
 
 func TestWithReadTimeout(t *testing.T) {

--- a/http/retryhttp/client.go
+++ b/http/retryhttp/client.go
@@ -36,13 +36,21 @@ func (c *FastHttpRetryClient) Do(req *fasthttp.Request, resp *fasthttp.Response)
 func (c *FastHttpRetryClient) DoWithRetry(req *fasthttp.Request, resp *fasthttp.Response, attempts uint) error {
 	err := c.Client.Do(req, resp)
 
-	if attempts == 1 || err == nil || !strings.Contains(err.Error(), "broken pipe") {
+	// A broken pipe means the write failed, not that the backend never read and committed
+	// the request. Only GET/HEAD are safe to replay blind; http.Client's RetryIf one layer
+	// down carries the matching gate.
+	if attempts == 1 || err == nil || !isRetryableMethod(req) || !strings.Contains(err.Error(), "broken pipe") {
 		return err
 	}
 
 	slog.Warn("retrying request due to an error", "attempt", attempts, "error", err)
 
 	return c.DoWithRetry(req, resp, attempts-1)
+}
+
+// isRetryableMethod reports whether req may be safely replayed after a write failure.
+func isRetryableMethod(req *fasthttp.Request) bool {
+	return req.Header.IsGet() || req.Header.IsHead()
 }
 
 func (c *FastHttpRetryClient) WithRetryAttempts(attempts uint) Client {

--- a/http/retryhttp/client_test.go
+++ b/http/retryhttp/client_test.go
@@ -1,8 +1,14 @@
 package retryhttp
 
 import (
+	"bufio"
 	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
@@ -32,6 +38,47 @@ func TestDoWithRetry(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDoWithRetryMutatingMethodNotRetried(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := httpmock.NewClientMock(ctrl)
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(1).Return(fmt.Errorf("unknown error: broken pipe or closed connection"))
+
+	client := FastHttpRetryClient{
+		Client: c,
+	}
+	client.WithRetryAttempts(2)
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fasthttp.MethodPost)
+
+	err := client.Do(req, &fasthttp.Response{})
+
+	assert.Error(t, err)
+}
+
+func TestIsRetryableMethod(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{fasthttp.MethodGet, true},
+		{fasthttp.MethodHead, true},
+		{fasthttp.MethodPost, false},
+		{fasthttp.MethodPut, false},
+		{fasthttp.MethodPatch, false},
+		{fasthttp.MethodDelete, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := &fasthttp.Request{}
+			req.Header.SetMethod(tt.method)
+
+			assert.Equal(t, tt.want, isRetryableMethod(req))
+		})
+	}
+}
+
 func TestWithRetryAttempts(t *testing.T) {
 	client := FastHttpRetryClient{
 		Client: &http.FastHttpClient{},
@@ -39,4 +86,191 @@ func TestWithRetryAttempts(t *testing.T) {
 	client.WithRetryAttempts(3)
 
 	assert.Equal(t, uint(3), client.attempts)
+}
+
+// Regression coverage for the no-retry-on-mutating-methods gates. These drive the real
+// client stack against a listener that behaves like a worker which commits the write then
+// dies: it fully reads the request before misbehaving. A regression in either gate shows
+// up as the same mutating request being delivered more than once.
+
+// readFullRequestLine reads headers plus any Content-Length body, reporting whether a full
+// request arrived.
+func readFullRequestLine(c net.Conn) bool {
+	br := bufio.NewReader(c)
+	contentLength := 0
+
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			fmt.Sscanf(strings.TrimSpace(line[len("content-length:"):]), "%d", &contentLength)
+		}
+		if line == "\r\n" {
+			break
+		}
+	}
+
+	if contentLength == 0 {
+		return true
+	}
+
+	body := make([]byte, contentLength)
+	for read := 0; read < contentLength; {
+		n, err := br.Read(body[read:])
+		if err != nil {
+			return false
+		}
+		read += n
+	}
+
+	return true
+}
+
+// misbehavingBackend accepts connections, fully reads and counts each request, then runs
+// behave on the raw connection. behave gets a stop channel closed at t.Cleanup so a
+// blocking behaviour can exit early instead of outliving the test.
+func misbehavingBackend(t *testing.T, delivered *int64, behave func(c net.Conn, stop <-chan struct{})) net.Listener {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	conns := make(map[net.Conn]struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			conns[c] = struct{}{}
+			mu.Unlock()
+
+			wg.Add(1)
+			go func(c net.Conn) {
+				defer wg.Done()
+				defer func() {
+					mu.Lock()
+					delete(conns, c)
+					mu.Unlock()
+					_ = c.Close()
+				}()
+				if readFullRequestLine(c) {
+					atomic.AddInt64(delivered, 1)
+					behave(c, stop)
+				}
+			}(c)
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		close(stop)
+
+		mu.Lock()
+		for c := range conns {
+			_ = c.Close()
+		}
+		mu.Unlock()
+
+		wg.Wait()
+	})
+
+	return ln
+}
+
+// The io.EOF replay: the backend reads the POST body, so it could have committed the
+// write, then closes without answering.
+func TestPOSTDeliveredOnceOnSilentClose(t *testing.T) {
+	var delivered int64
+	ln := misbehavingBackend(t, &delivered, func(c net.Conn, stop <-chan struct{}) { /* close with no response */ })
+
+	c := NewFastHttpRetryClient()
+	c.WithReadTimeout(2 * time.Second)
+	c.WithWriteTimeout(2 * time.Second)
+	c.WithRetryAttempts(2) // production value (service/api.httpRetryAttempts)
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://" + ln.Addr().String() + "/v1/wallets/1/charges")
+	req.Header.SetContentType("application/json")
+	req.SetBody([]byte(`{"type":"-","amount":100,"title":"coffee"}`))
+
+	err := c.Do(req, resp)
+
+	assert.Error(t, err)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&delivered),
+		"POST must be delivered to the backend exactly once, not replayed on io.EOF")
+}
+
+// The read-timeout replay: the backend reads the PUT body and never answers. It outlasts
+// the client's 200ms read timeout, then bails out via stop at cleanup.
+func TestPUTDeliveredOnceOnReadTimeout(t *testing.T) {
+	var delivered int64
+	ln := misbehavingBackend(t, &delivered, func(c net.Conn, stop <-chan struct{}) {
+		select {
+		case <-time.After(3 * time.Second):
+		case <-stop:
+		}
+	})
+
+	c := NewFastHttpRetryClient()
+	c.WithReadTimeout(200 * time.Millisecond)
+	c.WithWriteTimeout(2 * time.Second)
+	c.WithRetryAttempts(2)
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI("http://" + ln.Addr().String() + "/v1/profile/password")
+	req.Header.SetContentType("application/json")
+	req.SetBody([]byte(`{"password":"old","newPassword":"new"}`))
+
+	err := c.Do(req, resp)
+
+	assert.Error(t, err)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&delivered),
+		"PUT must be delivered to the backend exactly once, not replayed on a read timeout")
+}
+
+// The third mutating method the audit measured being replayed.
+func TestDELETEDeliveredOnceOnSilentClose(t *testing.T) {
+	var delivered int64
+	ln := misbehavingBackend(t, &delivered, func(c net.Conn, stop <-chan struct{}) { /* close with no response */ })
+
+	c := NewFastHttpRetryClient()
+	c.WithReadTimeout(2 * time.Second)
+	c.WithRetryAttempts(2)
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodDelete)
+	req.SetRequestURI("http://" + ln.Addr().String() + "/v1/wallets/1/charges/abc")
+
+	err := c.Do(req, resp)
+
+	assert.Error(t, err)
+	assert.EqualValues(t, 1, atomic.LoadInt64(&delivered),
+		"DELETE must be delivered to the backend exactly once, not replayed on io.EOF")
 }

--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -132,6 +132,9 @@ func (r *RedisHandler) Handler(h fasthttp.RequestHandler) fasthttp.RequestHandle
 		userCtx := r.newUserContext(cookie.ReadCSRFCookie(ctx))
 		span.SetAttributes(traces.AttributesGetter(userCtx)...)
 
+		// Load-bearing: this returns before h(ctx) forwards to the API, so a 417 proves the
+		// request never reached it — that is why the frontend can safely replay a mutating
+		// request after one. Do not reorder relative to h(ctx) below.
 		if err := r.validateCsrfRequest(spanCtx, userCtx, method); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "invalid")

--- a/router/router.go
+++ b/router/router.go
@@ -32,7 +32,9 @@ func (r *Router) register() {
 
 	r.POST("/api/auth/login", r.api.AuthSetHandler)
 	r.POST("/api/auth/login/passkey", r.api.AuthSetHandler)
-	r.POST("/api/auth/login/passkey/init", r.api.CaptchaVerifyHandler)
+	// GET: both the backend route and the only client use it. As POST this handler was
+	// unreachable and the real GET fell through to the catch-all below, skipping captcha.
+	r.GET("/api/auth/login/passkey/init", r.api.CaptchaVerifyHandler)
 	r.POST("/api/auth/register", r.api.AuthSetHandler)
 	r.POST("/api/auth/provider/google", r.api.AuthSetHandler)
 	r.POST("/api/auth/logout", r.api.AuthResetHandler)

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
 	"go.uber.org/mock/gomock"
 
 	"github.com/cash-track/gateway/mocks"
@@ -26,15 +27,49 @@ func TestNew(t *testing.T) {
 	assert.Contains(t, l["*"], "/api/{path:*}")
 
 	assert.NotNil(t, l["GET"])
-	assert.Len(t, l["GET"], 1)
+	assert.Len(t, l["GET"], 2)
 	assert.Contains(t, l["GET"], "/csrf")
+	// Passkey login init is captcha-verified on GET, matching the backend and the client.
+	assert.Contains(t, l["GET"], "/api/auth/login/passkey/init")
 
 	assert.NotNil(t, l["POST"])
-	assert.Len(t, l["POST"], 6)
+	assert.Len(t, l["POST"], 5)
 	assert.Contains(t, l["POST"], "/api/auth/login")
 	assert.Contains(t, l["POST"], "/api/auth/login/passkey")
-	assert.Contains(t, l["POST"], "/api/auth/login/passkey/init")
+	assert.NotContains(t, l["POST"], "/api/auth/login/passkey/init")
 	assert.Contains(t, l["POST"], "/api/auth/logout")
 	assert.Contains(t, l["POST"], "/api/auth/register")
 	assert.Contains(t, l["POST"], "/api/auth/provider/google")
+}
+
+// The table above only proves which paths are registered. These dispatch a real request to
+// prove the passkey-init GET reaches the captcha handler and not the catch-all proxy.
+func TestPasskeyLoginInitGetIsCaptchaVerified(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	a := mocks.NewApiHandlerMock(ctrl)
+	c := mocks.NewCsrfHandlerMock(ctrl)
+	a.EXPECT().CaptchaVerifyHandler(gomock.Any()).Times(1)
+
+	r := New(a, c)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.SetRequestURI("/api/auth/login/passkey/init")
+
+	r.Handler(&ctx)
+}
+
+func TestPasskeyLoginInitPostIsProxied(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	a := mocks.NewApiHandlerMock(ctrl)
+	c := mocks.NewCsrfHandlerMock(ctrl)
+	a.EXPECT().FullForwardedHandler(gomock.Any()).Times(1)
+
+	r := New(a, c)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/auth/login/passkey/init")
+
+	r.Handler(&ctx)
 }

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -44,6 +44,7 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		headers.AccessControlRequestHeaders,
 		headers.AccessControlRequestMethod,
 		headers.ContentType,
+		headers.IdempotencyKey,
 		headers.UserAgent,
 		headers.Referer,
 		headers.Origin,
@@ -209,6 +210,7 @@ func forwardResponse(ctx *fasthttp.RequestCtx, resp *fasthttp.Response) error {
 
 	headers.CopyFromResponse(resp, ctx, []string{
 		headers.ContentType,
+		headers.IdempotencyReplayed,
 		headers.RetryAfter,
 		headers.XCtApiSha,
 		headers.XCtApiVersion,

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -70,6 +70,63 @@ func TestFullForwardRequestWithAuth(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestForwardRequestCarriesIdempotencyKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", string(req.Header.Peek(headers.IdempotencyKey)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil, testBreaker(), testCoordinator())
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.Set(headers.IdempotencyKey, "3fa85f64-5717-4562-b3fc-2c963f66afa6")
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: []byte{0xA, 0x0, 0x0, 0x1}})
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
+func TestForwardRequestOmitsIdempotencyKeyWhenAbsent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Empty(t, req.Header.Peek(headers.IdempotencyKey))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil, testBreaker(), testCoordinator())
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: []byte{0xA, 0x0, 0x0, 0x1}})
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
 func TestForwardRequestWithBodyOverride(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	h := mocks.NewHttpRetryClientMock(ctrl)
@@ -310,6 +367,55 @@ func TestForwardRequestGatewayVersionHeadersPersistAcrossRefreshRetry(t *testing
 
 	ctx := fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	err := s.ForwardRequest(&ctx, nil)
+
+	assert.NoError(t, err)
+}
+
+// The key must survive a 401-refresh-retry cycle: without it on the retry, the API's
+// dedup middleware sees a brand-new request and can double-write.
+func TestForwardRequestIdempotencyKeyPersistsAcrossRefreshRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Eq(httpReadTimeout))
+	h.EXPECT().WithWriteTimeout(gomock.Eq(httpWriteTimeout))
+	h.EXPECT().WithRetryAttempts(gomock.Eq(httpRetryAttempts))
+	// 1st: original forwarded request, gets 401
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+
+		assert.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", string(req.Header.Peek(headers.IdempotencyKey)))
+
+		return nil
+	})
+	// 2nd: refresh request, built with its own req in refresh_token.go
+	h.EXPECT().DoTimeout(gomock.Any(), gomock.Any(), gomock.Eq(refreshHttpTimeout)).DoAndReturn(
+		func(req *fasthttp.Request, resp *fasthttp.Response, _ time.Duration) error {
+			resp.SetStatusCode(fasthttp.StatusOK)
+			resp.SetBodyString(fmt.Sprintf(`{"accessToken":"new_access_token","refreshToken":"new_refresh_token","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
+
+			return nil
+		})
+	// 3rd: retry, reusing the same req as the 1st — this is the assertion that matters.
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(req *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+
+		assert.Equal(t, "3fa85f64-5717-4562-b3fc-2c963f66afa6", string(req.Header.Peek(headers.IdempotencyKey)))
+
+		return nil
+	})
+
+	apiUrl, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{
+		ApiURI: apiUrl,
+	}, nil, testBreaker(), testCoordinator())
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.Header.Set(headers.IdempotencyKey, "3fa85f64-5717-4562-b3fc-2c963f66afa6")
 	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
 	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
 
@@ -787,6 +893,20 @@ func TestForwardResponse(t *testing.T) {
 	assert.Equal(t, "deadbeef", string(ctx.Response.Header.Peek(headers.XCtApiSha)))
 	assert.Equal(t, "123", string(ctx.Response.Header.Peek(headers.XRateLimit)))
 	assert.Equal(t, "2", string(ctx.Response.Header.Peek(headers.XRateLimitRemaining)))
+}
+
+// Diagnostic header, but still relayed back like the other API-set headers.
+func TestForwardResponseRelaysIdempotencyReplayed(t *testing.T) {
+	ctx := fasthttp.RequestCtx{}
+
+	resp := fasthttp.Response{}
+	resp.SetStatusCode(fasthttp.StatusOK)
+	resp.Header.Set(headers.IdempotencyReplayed, "true")
+
+	err := forwardResponse(&ctx, &resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "true", string(ctx.Response.Header.Peek(headers.IdempotencyReplayed)))
 }
 
 // CORS response headers are decided entirely by headers.CorsHandler, which wraps


### PR DESCRIPTION
## Problem statement

Two separate defects, both found while auditing retry behaviour between the clients and the PHP API.

**1. The gateway silently replays mutating requests.** `http.Client` was left on fasthttp's defaults: `MaxIdemponentCallAttempts` = 5, with PUT counted as idempotent. A `POST`/`PUT`/`PATCH`/`DELETE` whose write fails *after* the backend has already read and committed it is retried blind, applying the side effect twice — a duplicated charge. `retryhttp` had the same hole on its broken-pipe path: a broken pipe means the write failed, not that the request never arrived.

**2. `/api/auth/login/passkey/init` skipped captcha entirely.** It was registered as `POST`, but the backend route and the only client both use `GET`. The `POST` registration was unreachable, and the real `GET` fell through to the catch-all proxy — bypassing `CaptchaVerifyHandler`.

## Changes

**No retries on mutating methods.**
- `http.Client`: `MaxIdemponentCallAttempts` drops to 1. That value is the only thing that actually closes the hole — fasthttp retries any method on `io.EOF` regardless of `RetryIf`, so `RetryIf` alone is not enough. It is kept as an explicit statement of intent, gating on GET/HEAD. PUT is excluded despite being RFC-idempotent, because the gateway's PUT routes are read-modify-write. GET/HEAD lose retries at this layer; `retryhttp` one level up still covers them.
- `retryhttp`: the broken-pipe retry is now gated on GET/HEAD too.

**Idempotency-Key relay.** `Idempotency-Key` is forwarded to the API and `Idempotency-Replayed` is forwarded back to the client, including across the internal 401-refresh-retry (which would otherwise re-issue the request without the header). The gateway never interprets the value — the API middleware is the authoritative deduplicator, which is what makes retries at Traefik, Cloudflare, or the browser safe.

**Passkey init on GET.** `r.GET("/api/auth/login/passkey/init", r.api.CaptchaVerifyHandler)`. The spec was already self-contradictory here — it described the challenge as coming from `GET /api/auth/login/passkey/init` while defining the operation as `post:`; both now agree.

`docs/openapi.yaml` documents the header on every mutating route, `Idempotency-Replayed`, and the corrected method.

## Verification

Independent code review across three rounds; all material findings addressed.

- `make test` (race detector on) — all 16 packages pass. `router` and `router/api` remain at 100.0% statement coverage.
- `golangci-lint run` — 0 issues.

The route fix is pinned by **dispatch** tests, not just route-table assertions: the table only proves which paths are registered, so `TestPasskeyLoginInitGetIsCaptchaVerified` and `TestPasskeyLoginInitPostIsProxied` drive real requests through the router and assert on the handler actually reached. Mutation-checked — reverting `r.GET` to `r.POST` fails all three router tests with `missing call(s) to CaptchaVerifyHandler`; restoring makes them green again.

`MaxIdemponentCallAttempts: 1` is pinned by `TestDoNotRetriedAtThisLayerRegardlessOfMethod`, which fails if the value is raised.

A live A/B probe against the local stack was **not** decisive and is not being claimed as proof: `CAPTCHA_SECRET` is empty there, so both the fixed and unfixed gateway return 200 for GET / 404 for POST.

End-to-end against the full local stack (Traefik → this gateway → PHP API): the frontend Playwright suite ran 198/198 green, with `Idempotency-Key` set on every mutating call and relayed through.

Merge alongside cash-track/api#223 (that PR adds the middleware this header feeds).
