### PR TITLE
fix(gateway): exempt login endpoints from CSRF validation

### DIFF
--- a/router/csrf/redis_handler.go
+++ b/router/csrf/redis_handler.go
@@ -69,6 +69,15 @@ func newRedisUpGauge() prometheus.Gauge {
 	return g
 }
 
+// Endpoints that replace whatever session the request arrived with. Seed() owns the CSRF
+// lifecycle for these; see Handler for why they bypass validation and rotation entirely.
+var sessionEstablishingPaths = map[string]bool{
+	"/api/auth/login":           true,
+	"/api/auth/login/passkey":   true,
+	"/api/auth/register":        true,
+	"/api/auth/provider/google": true,
+}
+
 var (
 	csrfRequiredForMethods = map[string]bool{
 		fasthttp.MethodPost:   true,
@@ -117,6 +126,18 @@ func (r *RedisHandler) Handler(h fasthttp.RequestHandler) fasthttp.RequestHandle
 		method := string(ctx.Request.Header.Method())
 
 		if method == fasthttp.MethodOptions {
+			h(ctx)
+
+			return
+		}
+
+		// The token of the session being replaced says nothing about a login or register
+		// request, and enforcing it locks the user out: the Redis entry lives 10 minutes
+		// while the auth cookies survive until the refresh token expires, so a stale
+		// cshtrka cookie is enough to make IsLogged() true with nothing left to validate
+		// against. Skipping rotation matters just as much — it runs off the *old* user
+		// context and would overwrite the cookie Seed() just wrote for the new session.
+		if sessionEstablishingPaths[string(ctx.Path())] {
 			h(ctx)
 
 			return

--- a/router/csrf/redis_handler_test.go
+++ b/router/csrf/redis_handler_test.go
@@ -29,6 +29,9 @@ func TestHandler(t *testing.T) {
 		expectStatus        int
 		expectBody          string
 		expectCsrfCookieSet bool
+		// The case primes a Get that would fail the request and asserts it is never
+		// consumed, proving the CSRF store was not touched at all.
+		expectRedisUntouched bool
 	}{
 		"TokenValidForPost": {
 			request: func() *fasthttp.RequestCtx {
@@ -100,6 +103,94 @@ func TestHandler(t *testing.T) {
 			setup: func(mock redismock.ClientMock) {
 			},
 			expectPass: true,
+		},
+		// A stale access-token cookie must not gate the endpoints that replace it. The
+		// Redis entry lives 10 minutes while the auth cookies live until the refresh token
+		// expires, so validating here locks the user out of logging back in.
+		"SkippedForLoginWithStaleSession": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.SetRequestURI("/api/auth/login")
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:           true,
+			expectCsrfCookieSet:  false,
+			expectRedisUntouched: true,
+		},
+		"SkippedForPasskeyLoginWithStaleSession": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.SetRequestURI("/api/auth/login/passkey")
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:           true,
+			expectCsrfCookieSet:  false,
+			expectRedisUntouched: true,
+		},
+		"SkippedForRegisterWithStaleSession": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.SetRequestURI("/api/auth/register")
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:           true,
+			expectCsrfCookieSet:  false,
+			expectRedisUntouched: true,
+		},
+		"SkippedForGoogleProviderWithStaleSession": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.SetRequestURI("/api/auth/provider/google")
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:           true,
+			expectCsrfCookieSet:  false,
+			expectRedisUntouched: true,
+		},
+		// The exemption is by exact path: nothing below /api/auth/ inherits it.
+		"EnforcedForOtherAuthPaths": {
+			request: func() *fasthttp.RequestCtx {
+				ctx := fasthttp.RequestCtx{}
+				ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+				ctx.Request.SetRequestURI("/api/auth/login/passkey/other")
+				ctx.Request.Header.SetCookie(cookie.CsrfTokenCookieName, "csrf_token")
+				ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, accessToken)
+				return &ctx
+			}(),
+			setup: func(mock redismock.ClientMock) {
+				key := fmt.Sprintf("%s:%d:%d", keyPrefix, 123987, 987654321)
+				mock.ExpectGet(key).RedisNil()
+			},
+			expectPass:   false,
+			expectStatus: fasthttp.StatusExpectationFailed,
 		},
 		"FailForInvalidAccessToken": {
 			request: func() *fasthttp.RequestCtx {
@@ -209,7 +300,10 @@ func TestHandler(t *testing.T) {
 				assert.Equal(t, test.expectBody, string(test.request.Response.Body()))
 			}
 
-			if err := mock.ExpectationsWereMet(); err != nil {
+			if test.expectRedisUntouched {
+				assert.Error(t, mock.ExpectationsWereMet(),
+					"primed Get was consumed: the CSRF store should not be queried at all")
+			} else if err := mock.ExpectationsWereMet(); err != nil {
 				t.Error(err)
 			}
 		})


### PR DESCRIPTION
## Problem

Logging in with a passkey fails with a 417:

```json
{
    "message": "Unexpected error happened. Please try again later.",
    "error": "error on reading token: redis: nil"
}
```

The CSRF handler gates every mutating request whose `Auth.IsLogged()` is true, and `IsLogged()` is only *"a `cshtrka` cookie exists"* (`headers/cookie/auth.go:59`). The two lifetimes behind that do not match:

| | lifetime |
|---|---|
| `CT:csrf:*` Redis entry | 10 minutes (`tokenTtl`) |
| `cshtrka` / `cshtrkr` cookies | until the refresh token expires (days) |

Ten idle minutes are enough for a browser to still carry a valid access token with no CSRF entry left behind it. The next `POST /api/auth/login/passkey` is then validated against a token that no longer exists, `verify` correctly refuses to fail open on `redis.Nil`, and the request meant to *replace* that session is refused — with no way back in, because the website has no 417 recovery path.

Confirmed against a live stack: `redis-cli keys 'CT*'` returned 149 keys (idempotency, JWT blacklist, login-backoff) and zero `CT:csrf:*`. The error text is `error on reading token`, not `unable to verify with invalid user context`, so the access token parsed and JWKS-verified fine and the Redis lookup genuinely ran.

### Second defect on the same path

The rotation after `h(ctx)` builds its key from the **incoming** user context. `Login()` has already called `Seed()` with the new auth from the response body; the rotation then overwrites that fresh `cshtrkcsrf` cookie with a token keyed to the **old** access token, so the next mutation would 417 as well. A first-time login never hits it — no cookies means `IsLogged()` is false and the block is skipped — which is why it stayed invisible.

## Change

`/api/auth/login`, `/api/auth/login/passkey`, `/api/auth/register` and `/api/auth/provider/google` bypass both validation and rotation. `Seed()` owns the CSRF lifecycle for them.

Validating the outgoing session's token against a request that replaces it carries no signal, and the cookies are already `SameSite=Strict; HttpOnly; Secure` (`headers/cookie/cookie.go:19`) — which the handler's own comment names as the primary CSRF control, with this token as defence-in-depth.

## Verification

Five cases added to `TestHandler`; they fail on `main` with the real 417 and pass here.

Worth knowing for review: the first version of these tests **passed without the fix**. redismock returns a generic error for an unexpected call, which `verify` fail-opens on, so asserting "no Redis calls" by registering no expectations proves nothing. The committed version instead primes `ExpectGet(key).RedisNil()` and asserts it is never consumed, so the store is provably untouched. `EnforcedForOtherAuthPaths` pins the exemption to exact paths.

`make test` green across all 16 packages; `go vet` and `gofmt` clean.

## Related

Surfaced while fixing cash-track/website#101 (passkey login reused a single reCAPTCHA token). That failure was masking this one.

## Not addressed here

`POST /api/auth/logout` and `POST /api/auth/refresh` have the same 10-minute lockout, but the frontend recovers from a 417 by calling `GET /csrf` and replaying — that contract is why `validateCsrfRequest` returns before `h(ctx)`. The underlying smell is the 10-minute TTL sitting behind a multi-day cookie; worth revisiting separately.
