### PR TITLE
fix(gateway): retry idempotent requests on stale pooled connections

### DIFF
--- a/captcha/google_recaptcha.go
+++ b/captcha/google_recaptcha.go
@@ -110,6 +110,9 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 	span.SetAttributes(traces.RequestAttributes(req)...)
 
 	if err := p.client.Do(req, resp); err != nil {
+		// This returns a 500 to the caller, so it needs a log line and not just a span:
+		// the trace is sampled, the 500 is not.
+		slog.Error("captcha verify request failed", "client_ip", clientIp, "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "request error")
 
@@ -120,6 +123,11 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 
 	verifyResp := googleReCaptchaVerifyResponse{}
 	if err := json.Unmarshal(resp.Body(), &verifyResp); err != nil {
+		slog.Error("captcha verify response unreadable",
+			"client_ip", clientIp,
+			"status", resp.StatusCode(),
+			"error", err,
+		)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "read body error")
 

--- a/captcha/google_recaptcha_test.go
+++ b/captcha/google_recaptcha_test.go
@@ -1,7 +1,9 @@
 package captcha
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"net"
 	"testing"
 
@@ -13,6 +15,20 @@ import (
 	"github.com/cash-track/gateway/headers"
 	"github.com/cash-track/gateway/mocks"
 )
+
+// captureLogs redirects the default logger for one test. Verify's two error returns become
+// a 500 to the caller, and both used to reach the span only — a 500 with no log line left
+// the 14:38 passkey failure with nothing to diagnose.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	output := &bytes.Buffer{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	return output
+}
 
 func TestVerify(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -149,6 +165,7 @@ func TestVerifyEmptyChallenge(t *testing.T) {
 }
 
 func TestVerifyRequestFail(t *testing.T) {
+	output := captureLogs(t)
 	ctrl := gomock.NewController(t)
 	c := mocks.NewHttpRetryClientMock(ctrl)
 
@@ -168,9 +185,12 @@ func TestVerifyRequestFail(t *testing.T) {
 
 	assert.False(t, state)
 	assert.Error(t, err)
+	assert.Contains(t, output.String(), "captcha verify request failed")
+	assert.Contains(t, output.String(), `"level":"ERROR"`)
 }
 
 func TestVerifyBadResponse(t *testing.T) {
+	output := captureLogs(t)
 	ctrl := gomock.NewController(t)
 	c := mocks.NewHttpRetryClientMock(ctrl)
 
@@ -194,4 +214,6 @@ func TestVerifyBadResponse(t *testing.T) {
 
 	assert.False(t, state)
 	assert.Error(t, err)
+	assert.Contains(t, output.String(), "captcha verify response unreadable")
+	assert.Contains(t, output.String(), `"level":"ERROR"`)
 }

--- a/http/client.go
+++ b/http/client.go
@@ -10,6 +10,10 @@ const (
 	ReadTimeout  = 5 * time.Second
 	WriteTimeout = 5 * time.Second
 	Concurrency  = 4096
+
+	// IdleConnDuration must stay well under the time a backend container survives a
+	// redeploy, so a stale socket is reaped rather than handed to the next request.
+	IdleConnDuration = 10 * time.Second
 )
 
 type Client interface {
@@ -28,9 +32,12 @@ type FastHttpClient struct {
 func NewFastHttpClient() Client {
 	return &FastHttpClient{
 		Client: &fasthttp.Client{
-			ReadTimeout:                   ReadTimeout,
-			WriteTimeout:                  WriteTimeout,
-			MaxIdleConnDuration:           time.Hour,
+			ReadTimeout:  ReadTimeout,
+			WriteTimeout: WriteTimeout,
+			// Bounds how long a pooled socket may sit idle. An hour let the pool outlive
+			// the backend: every API container replacement stranded connections the peer
+			// had already dropped, and the first request on each answered 502.
+			MaxIdleConnDuration:           IdleConnDuration,
 			NoDefaultUserAgentHeader:      true,
 			DisableHeaderNamesNormalizing: true,
 			DisablePathNormalizing:        true,
@@ -40,7 +47,8 @@ func NewFastHttpClient() Client {
 			//
 			// Do not raise above 1: fasthttp retries any method on io.EOF regardless of
 			// RetryIf, so only this value closes that hole. GET/HEAD lose retries here as
-			// a result — retryhttp one layer up still covers them. Pinned by
+			// a result; retryhttp.FastHttpRetryClient owns them instead, where the method
+			// gate and the error classification are both explicit. Pinned by
 			// TestDoNotRetriedAtThisLayerRegardlessOfMethod.
 			MaxIdemponentCallAttempts: 1,
 			// Unreachable at MaxIdemponentCallAttempts = 1; kept as a statement of intent.

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -22,6 +22,16 @@ func TestNewFastHttpClient(t *testing.T) {
 	assert.NotNil(t, fhc.RetryIf)
 }
 
+// The pool must not outlive the backend. At an hour, every API container replacement left
+// the gateway holding dead sockets and answering 502 until they aged out.
+func TestNewFastHttpClientIdleConnDuration(t *testing.T) {
+	fhc := NewFastHttpClient().(*FastHttpClient)
+
+	assert.Positive(t, fhc.MaxIdleConnDuration)
+	assert.LessOrEqual(t, fhc.MaxIdleConnDuration, 30*time.Second,
+		"idle sockets must be reaped soon enough that a container swap does not strand them")
+}
+
 // Tests the RetryIf predicate in isolation; it cannot catch MaxIdemponentCallAttempts
 // being raised above 1 (see io.EOF in client.go). That is covered end-to-end by
 // TestDoNotRetriedAtThisLayerRegardlessOfMethod below.

--- a/http/retryhttp/client.go
+++ b/http/retryhttp/client.go
@@ -1,14 +1,20 @@
 package retryhttp
 
 import (
+	"errors"
+	"io"
 	"log/slog"
 	"strings"
+	"syscall"
 
 	"github.com/cash-track/gateway/http"
 	"github.com/valyala/fasthttp"
 )
 
-const defaultRetryAttempts = 1
+// defaultRetryAttempts gives one retry to consumers that never call WithRetryAttempts —
+// jwks.HttpProvider is the only one. At 1 its hourly key refresh had a single attempt and
+// died on the first stale socket.
+const defaultRetryAttempts = 2
 
 type Client interface {
 	http.Client
@@ -36,21 +42,54 @@ func (c *FastHttpRetryClient) Do(req *fasthttp.Request, resp *fasthttp.Response)
 func (c *FastHttpRetryClient) DoWithRetry(req *fasthttp.Request, resp *fasthttp.Response, attempts uint) error {
 	err := c.Client.Do(req, resp)
 
-	// A broken pipe means the write failed, not that the backend never read and committed
-	// the request. Only GET/HEAD are safe to replay blind; http.Client's RetryIf one layer
-	// down carries the matching gate.
-	if attempts == 1 || err == nil || !isRetryableMethod(req) || !strings.Contains(err.Error(), "broken pipe") {
+	if attempts == 1 || err == nil || !isRetryableMethod(req) || !isRetryableTransportError(err) {
 		return err
 	}
 
-	slog.Warn("retrying request due to an error", "attempt", attempts, "error", err)
+	// Method and URI make the line correlatable: this layer has no request context, so
+	// without them a retry warning cannot be tied to the error it preceded.
+	slog.Warn("retrying request due to an error",
+		"attempt", attempts,
+		"method", string(req.Header.Method()),
+		"uri", string(req.URI().Path()),
+		"error", err,
+	)
 
 	return c.DoWithRetry(req, resp, attempts-1)
 }
 
-// isRetryableMethod reports whether req may be safely replayed after a write failure.
+// isRetryableMethod reports whether req may be safely replayed after a transport failure.
+// A dead connection cannot distinguish "never arrived" from "committed, then the socket
+// died", so only the methods that are safe to deliver twice qualify. http.Client's RetryIf
+// one layer down carries the matching gate.
 func isRetryableMethod(req *fasthttp.Request) bool {
 	return req.Header.IsGet() || req.Header.IsHead()
+}
+
+// isRetryableTransportError reports whether err means the connection failed rather than
+// the backend answering. Those are the errors a fresh connection can recover from.
+//
+// fasthttp surfaces a dropped keep-alive socket as ErrConnectionClosed, not as a broken
+// pipe; matching only the latter is what turned an API redeploy into a burst of 502s.
+// Timeouts are deliberately absent: the request may well have been delivered, and a
+// replay only doubles the latency budget.
+func isRetryableTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, fasthttp.ErrConnectionClosed) || errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	// Some paths lose the sentinel to fmt.Errorf without %w, so the text is the only
+	// signal left.
+	text := err.Error()
+
+	return strings.Contains(text, "broken pipe") ||
+		strings.Contains(text, "connection reset") ||
+		strings.Contains(text, "closed connection")
 }
 
 func (c *FastHttpRetryClient) WithRetryAttempts(attempts uint) Client {

--- a/http/retryhttp/client_test.go
+++ b/http/retryhttp/client_test.go
@@ -3,10 +3,13 @@ package retryhttp
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -273,4 +276,159 @@ func TestDELETEDeliveredOnceOnSilentClose(t *testing.T) {
 	assert.Error(t, err)
 	assert.EqualValues(t, 1, atomic.LoadInt64(&delivered),
 		"DELETE must be delivered to the backend exactly once, not replayed on io.EOF")
+}
+
+// The production regression: a GET whose pooled connection died surfaces
+// fasthttp.ErrConnectionClosed, not "broken pipe". Gating the retry on the literal
+// substring let five GETs turn into 502s the moment the API container was replaced.
+func TestDoWithRetryRetriesGetOnTransportError(t *testing.T) {
+	tests := map[string]error{
+		"ConnectionClosed": fasthttp.ErrConnectionClosed,
+		"EOF":              io.EOF,
+		"BrokenPipe":       &net.OpError{Op: "write", Err: os.NewSyscallError("write", syscall.EPIPE)},
+		"ConnectionReset":  &net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)},
+		"WrappedEOF":       fmt.Errorf("api request: %w", io.EOF),
+	}
+
+	for name, transportErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			c := httpmock.NewClientMock(ctrl)
+			c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(2).Return(transportErr)
+
+			client := FastHttpRetryClient{Client: c}
+			client.WithRetryAttempts(2)
+
+			req := &fasthttp.Request{}
+			req.Header.SetMethod(fasthttp.MethodGet)
+
+			assert.Error(t, client.Do(req, &fasthttp.Response{}))
+		})
+	}
+}
+
+// A response that arrived but timed out, or any application-level failure, says nothing
+// about the connection: replaying it only doubles the latency budget.
+func TestDoWithRetryDoesNotRetryOnNonTransportError(t *testing.T) {
+	tests := map[string]error{
+		"Timeout":      fasthttp.ErrTimeout,
+		"NoFreeConns":  fasthttp.ErrNoFreeConns,
+		"Unclassified": fmt.Errorf("something else went wrong"),
+	}
+
+	for name, err := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			c := httpmock.NewClientMock(ctrl)
+			c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(1).Return(err)
+
+			client := FastHttpRetryClient{Client: c}
+			client.WithRetryAttempts(2)
+
+			req := &fasthttp.Request{}
+			req.Header.SetMethod(fasthttp.MethodGet)
+
+			assert.Error(t, client.Do(req, &fasthttp.Response{}))
+		})
+	}
+}
+
+// A transport error is still not a licence to replay a mutating request.
+func TestDoWithRetryDoesNotRetryMutatingMethodOnTransportError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := httpmock.NewClientMock(ctrl)
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(1).Return(fasthttp.ErrConnectionClosed)
+
+	client := FastHttpRetryClient{Client: c}
+	client.WithRetryAttempts(2)
+
+	req := &fasthttp.Request{}
+	req.Header.SetMethod(fasthttp.MethodPost)
+
+	assert.Error(t, client.Do(req, &fasthttp.Response{}))
+}
+
+// jwks.HttpProvider never calls WithRetryAttempts, so the default is the only thing
+// standing between an hourly key refresh and a single-attempt failure. Both refreshes
+// after the default dropped to 1 failed in production.
+func TestNewFastHttpRetryClientDefaultsToOneRetry(t *testing.T) {
+	c, ok := NewFastHttpRetryClient().(*FastHttpRetryClient)
+
+	assert.True(t, ok)
+	assert.EqualValues(t, 2, c.attempts,
+		"a consumer that never calls WithRetryAttempts must still get one retry")
+}
+
+func TestIsRetryableTransportError(t *testing.T) {
+	tests := map[string]struct {
+		err  error
+		want bool
+	}{
+		"Nil":              {nil, false},
+		"ConnectionClosed": {fasthttp.ErrConnectionClosed, true},
+		"EOF":              {io.EOF, true},
+		"BrokenPipe":       {&net.OpError{Op: "write", Err: os.NewSyscallError("write", syscall.EPIPE)}, true},
+		"ConnectionReset":  {&net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)}, true},
+		"BrokenPipeString": {fmt.Errorf("unknown error: broken pipe or closed connection"), true},
+		"Timeout":          {fasthttp.ErrTimeout, false},
+		"Other":            {fmt.Errorf("bad gateway"), false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRetryableTransportError(tt.err))
+		})
+	}
+}
+
+// End-to-end shape of the incident: the first connection is closed without a response —
+// a keep-alive socket the backend had already dropped — and the retry must land on a
+// fresh one and succeed, so the browser never sees the 502.
+func TestGETRecoversFromStaleConnection(t *testing.T) {
+	var accepted int64
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+
+			go func(conn net.Conn) {
+				defer func() { _ = conn.Close() }()
+
+				// The first connection dies the way a dropped keep-alive socket does:
+				// closed before a single response byte is written.
+				if atomic.AddInt64(&accepted, 1) == 1 {
+					return
+				}
+
+				if readFullRequestLine(conn) {
+					_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"))
+				}
+			}(conn)
+		}
+	}()
+
+	c := NewFastHttpRetryClient()
+	c.WithReadTimeout(2 * time.Second)
+	c.WithWriteTimeout(2 * time.Second)
+
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://" + ln.Addr().String() + "/v1/profile")
+
+	assert.NoError(t, c.Do(req, resp))
+	assert.Equal(t, fasthttp.StatusOK, resp.StatusCode())
+	assert.EqualValues(t, 2, atomic.LoadInt64(&accepted))
 }


### PR DESCRIPTION
## Context

Production log audit of v1.4.4 (2026-08-26). Every API container replacement produced user-visible 502s, and both hourly JWKS refreshes after the deploy failed. Three defects, all introduced or exposed by c358bc8.

Evidence, all after v1.4.4 went live at 13:05:16 and none in the preceding 7 days:

```
13:20:05  ERROR forward request failed  GET /api/wallets/374/tags   ... the server closed connection
13:20:05  ERROR forward request failed  GET /api/wallets/374        (x5, all 502 to the browser)
13:20:16  WARN  jwks periodic refresh failed  ... write: broken pipe
14:15:52  ERROR forward request failed  GET /api/profile            (x2, 502)
14:20:16  WARN  jwks periodic refresh failed  ... write: broken pipe
14:38:13  GET /api/auth/login/passkey/init -> 500, no gateway log line at all
```

The container that ran 08-24 08:37 to 08-26 13:05 did ~52 hourly JWKS refreshes with zero failures. The first two after v1.4.4 both failed.

## Defects

**1. The retry gate matched the wrong error.** `retryhttp` retried only when the error text contained `"broken pipe"`. fasthttp surfaces a dropped keep-alive socket as `ErrConnectionClosed` (`"the server closed connection before returning the first response byte"`), which does not contain that substring — so those GETs were retried at neither layer and went straight to 502.

Replaced with `isRetryableTransportError`, matching sentinels through `errors.Is` (`fasthttp.ErrConnectionClosed`, `io.EOF`, `syscall.EPIPE`, `syscall.ECONNRESET`) with a string fallback for errors that lost the sentinel to a `fmt.Errorf` without `%w`.

Timeouts are deliberately excluded: the request may well have been delivered, and a replay only doubles the latency budget. `isRetryableMethod` is untouched, so the duplicate-charge hole c358bc8 closed stays closed.

**2. `defaultRetryAttempts = 1` disabled retryhttp for its only default consumer.** `DoWithRetry` short-circuits on `attempts == 1`. `jwks.HttpProvider` sets a read timeout but never calls `WithRetryAttempts`, so its hourly key refresh had exactly one attempt. Fixed at the default rather than in the provider — a retry client that does not retry by default is the bug. `service/api` and `captcha` already pass 2 explicitly and are unaffected.

**3. `MaxIdleConnDuration: time.Hour` let the pool outlive the backend.** An hour of stale sockets after every container swap is the root enabler for both of the above. Now `IdleConnDuration = 10s`, bounding the window; with the retry restored the user-visible window closes.

The comment on `MaxIdemponentCallAttempts` claimed *"GET/HEAD lose retries here as a result — retryhttp one layer up still covers them."* That was false, and is what let the gap ship. Corrected.

## Also

- `captcha.Verify` now logs both error returns. They map to a 500 via `NewCaptchaErrorResponse`, and previously reached the OTel span only — which is why the 14:38:13 passkey failure had no log line. Traces are sampled; the 500 is not.
- The retry warning carries method and URI. That layer has no request context, so without them a retry warning cannot be tied to the error it preceded (visible at 14:15:52, where the WARN and the ERROR were two different requests).

## Verification

`go test -race -count=1 ./...` green, `go vet ./...` clean, `golangci-lint run ./...` reports 0 issues.

Tests were written before the fixes and observed failing. Reverting `isRetryableTransportError` to the old narrow gate fails nine subtests plus `TestGETRecoversFromStaleConnection`, which drives the real client stack against a listener that drops the first connection unanswered and serves the second — the incident's exact shape. Restoring the classifier makes them pass.

The pre-existing delivered-exactly-once invariants for POST/PUT/DELETE (`TestPOSTDeliveredOnceOnSilentClose`, `TestPUTDeliveredOnceOnReadTimeout`, `TestDELETEDeliveredOnceOnSilentClose`, `TestDoNotRetriedAtThisLayerRegardlessOfMethod`) all still hold.

## Out of scope

`DNSCacheDuration: time.Hour` on the same client. On Docker Compose a recreated container can change IP, and a one-hour DNS cache would keep the gateway dialling a dead address even with fresh connections. It did not fire here — `172.18.0.23` was reused across both API container generations — so this PR stays scoped to what the evidence showed. Same class of bug, worth a follow-up.