### PR TITLE
feat(gateway): add application Prometheus metrics

### DIFF
--- a/captcha/google_recaptcha.go
+++ b/captcha/google_recaptcha.go
@@ -80,12 +80,14 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 	if p.secret == "" {
 		span.SetStatus(codes.Ok, "disabled")
 		slog.Info("captcha secret empty, skipping verify", "client_ip", clientIp)
+		observeCaptchaResult(resultDisabled)
 
 		return true, nil
 	}
 
 	if string(ctx.Request.Header.Method()) == fasthttp.MethodOptions {
 		span.SetStatus(codes.Ok, "unsupported method")
+		observeCaptchaResult(resultDisabled)
 
 		return true, nil
 	}
@@ -94,6 +96,7 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 	if challenge == nil || string(challenge) == "" {
 		span.SetStatus(codes.Error, "empty challenge")
 		slog.Warn("captcha challenge empty", "client_ip", clientIp)
+		observeCaptchaResult(resultMissed)
 
 		return false, nil
 	}
@@ -115,6 +118,7 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 		slog.Error("captcha verify request failed", "client_ip", clientIp, "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "request error")
+		observeCaptchaResult(resultError)
 
 		return false, fmt.Errorf("captcha verify request error: %w", err)
 	}
@@ -130,11 +134,13 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 		)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "read body error")
+		observeCaptchaResult(resultError)
 
 		return false, fmt.Errorf("captcha verify response unexpected: %w", err)
 	}
 
 	span.SetAttributes(traces.AttributesGetter(&verifyResp)...)
+	observeCaptchaScore(verifyResp.Score)
 
 	if !verifyResp.Success {
 		slog.Warn("captcha verify unsuccessful",
@@ -143,12 +149,14 @@ func (p *GoogleReCaptchaProvider) Verify(ctx *fasthttp.RequestCtx) (bool, error)
 			"error", strings.Join(verifyResp.ErrorCodes, ", "),
 		)
 		span.SetStatus(codes.Error, "validation failed")
+		observeCaptchaResult(resultMissed)
 
 		return false, nil
 	}
 
 	slog.Info("captcha verify ok", "client_ip", clientIp)
 	span.SetStatus(codes.Ok, "ok")
+	observeCaptchaResult(resultSolved)
 
 	return true, nil
 }

--- a/captcha/metrics.go
+++ b/captcha/metrics.go
@@ -1,0 +1,51 @@
+package captcha
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	metricsNamespace = "gateway"
+	metricsSubsystem = "captcha"
+
+	// resultSolved marks a verification that passed (reCAPTCHA reported success).
+	resultSolved = "solved"
+	// resultMissed marks a request that reached the verify step but failed it: a
+	// missing challenge token or a reCAPTCHA "success:false" (bad/low-quality token).
+	resultMissed = "missed"
+	// resultError marks a transport or response-parse failure talking to Google.
+	resultError = "error"
+	// resultDisabled marks the empty-secret short-circuit (captcha turned off) and the
+	// CORS preflight bypass — no verification is performed.
+	resultDisabled = "disabled"
+)
+
+// captchaVerificationsTotal counts every call to Verify, bucketed by outcome.
+var captchaVerificationsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsSubsystem,
+	Name:      "verifications_total",
+	Help:      "reCAPTCHA verifications by outcome: solved, missed, error, disabled.",
+}, []string{"result"})
+
+// captchaScore observes the reCAPTCHA v3 score whenever Google returns one.
+var captchaScore = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsSubsystem,
+	Name:      "score",
+	Help:      "reCAPTCHA v3 score returned by Google (0.0 bot .. 1.0 human).",
+	Buckets:   []float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0},
+})
+
+func observeCaptchaResult(result string) {
+	captchaVerificationsTotal.WithLabelValues(result).Inc()
+}
+
+// observeCaptchaScore records a score only when Google actually returned one
+// (score is absent on most failure responses, unmarshalling to 0).
+func observeCaptchaScore(score float32) {
+	if score > 0 {
+		captchaScore.Observe(float64(score))
+	}
+}

--- a/captcha/metrics_test.go
+++ b/captcha/metrics_test.go
@@ -1,0 +1,148 @@
+package captcha
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/headers"
+	"github.com/cash-track/gateway/mocks"
+)
+
+func newMetricsTestCtx() *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetRemoteAddr(&net.TCPAddr{IP: []byte{0xA, 0x0, 0x0, 0x1}})
+	ctx.Request.Header.Set(headers.XCtCaptchaChallenge, "challenge")
+
+	return ctx
+}
+
+func newMetricsTestProvider(t *testing.T, secret string) (*GoogleReCaptchaProvider, *mocks.HttpRetryClientMock) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	c := mocks.NewHttpRetryClientMock(ctrl)
+	c.EXPECT().WithReadTimeout(gomock.Any())
+	c.EXPECT().WithWriteTimeout(gomock.Any())
+	c.EXPECT().WithRetryAttempts(gomock.Any())
+
+	return NewGoogleReCaptchaProvider(c, config.Config{CaptchaSecret: secret}), c
+}
+
+func TestVerifyMetricSolvedRecordsResultAndScore(t *testing.T) {
+	p, c := newMetricsTestProvider(t, "secret")
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"success":true,"score":0.9}`)
+		return nil
+	})
+
+	resultBefore := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultSolved))
+	scoreBefore := testutil.CollectAndCount(captchaScore)
+
+	ok, err := p.Verify(newMetricsTestCtx())
+
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, resultBefore+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultSolved)))
+	assert.GreaterOrEqual(t, testutil.CollectAndCount(captchaScore), scoreBefore)
+}
+
+func TestVerifyMetricMissedOnUnsuccessful(t *testing.T) {
+	p, c := newMetricsTestProvider(t, "secret")
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"success":false}`)
+		return nil
+	})
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultMissed))
+
+	ok, err := p.Verify(newMetricsTestCtx())
+
+	assert.False(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultMissed)))
+}
+
+func TestVerifyMetricMissedOnEmptyChallenge(t *testing.T) {
+	p, _ := newMetricsTestProvider(t, "secret")
+
+	ctx := newMetricsTestCtx()
+	ctx.Request.Header.Set(headers.XCtCaptchaChallenge, "")
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultMissed))
+
+	ok, err := p.Verify(ctx)
+
+	assert.False(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultMissed)))
+}
+
+func TestVerifyMetricErrorOnTransportFailure(t *testing.T) {
+	p, c := newMetricsTestProvider(t, "secret")
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).Return(fmt.Errorf("broken pipe"))
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultError))
+
+	_, err := p.Verify(newMetricsTestCtx())
+
+	assert.Error(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultError)))
+}
+
+func TestVerifyMetricErrorOnBadBody(t *testing.T) {
+	p, c := newMetricsTestProvider(t, "secret")
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		resp.SetBodyString(`{"success":true`)
+		return nil
+	})
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultError))
+
+	_, err := p.Verify(newMetricsTestCtx())
+
+	assert.Error(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultError)))
+}
+
+func TestVerifyMetricDisabledOnEmptySecret(t *testing.T) {
+	p, _ := newMetricsTestProvider(t, "")
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultDisabled))
+
+	ok, err := p.Verify(newMetricsTestCtx())
+
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultDisabled)))
+}
+
+func TestVerifyMetricDisabledOnOptions(t *testing.T) {
+	p, _ := newMetricsTestProvider(t, "secret")
+
+	ctx := newMetricsTestCtx()
+	ctx.Request.Header.SetMethod(fasthttp.MethodOptions)
+
+	before := testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultDisabled))
+
+	ok, err := p.Verify(ctx)
+
+	assert.True(t, ok)
+	assert.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(captchaVerificationsTotal.WithLabelValues(resultDisabled)))
+}
+
+func TestObserveCaptchaScoreIgnoresZero(t *testing.T) {
+	before := testutil.CollectAndCount(captchaScore)
+	observeCaptchaScore(0)
+	assert.Equal(t, before, testutil.CollectAndCount(captchaScore))
+}

--- a/http/retryhttp/client.go
+++ b/http/retryhttp/client.go
@@ -46,6 +46,8 @@ func (c *FastHttpRetryClient) DoWithRetry(req *fasthttp.Request, resp *fasthttp.
 		return err
 	}
 
+	retriesTotal.Inc()
+
 	// Method and URI make the line correlatable: this layer has no request context, so
 	// without them a retry warning cannot be tied to the error it preceded.
 	slog.Warn("retrying request due to an error",

--- a/http/retryhttp/metrics.go
+++ b/http/retryhttp/metrics.go
@@ -1,0 +1,17 @@
+package retryhttp
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// retriesTotal counts transport-error retries across every consumer of this
+// client (API forward path, captcha verify, JWKS refresh). A rising rate points
+// at upstream connection churn (redeploys, keep-alive drops) before it turns
+// into user-visible 502s.
+var retriesTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: "gateway",
+	Subsystem: "upstream",
+	Name:      "retries_total",
+	Help:      "Outbound HTTP requests retried after a retryable transport error.",
+})

--- a/http/retryhttp/metrics_test.go
+++ b/http/retryhttp/metrics_test.go
@@ -1,0 +1,41 @@
+package retryhttp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/mock/gomock"
+
+	httpmock "github.com/cash-track/gateway/mocks/http"
+)
+
+func TestRetriesTotalIncrementsOnRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := httpmock.NewClientMock(ctrl)
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(2).Return(fmt.Errorf("unknown error: broken pipe"))
+
+	client := FastHttpRetryClient{Client: c}
+	client.WithRetryAttempts(2)
+
+	before := testutil.ToFloat64(retriesTotal)
+	err := client.Do(&fasthttp.Request{}, &fasthttp.Response{})
+
+	assert.Error(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(retriesTotal))
+}
+
+func TestRetriesTotalUnchangedWithoutRetry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	c := httpmock.NewClientMock(ctrl)
+	c.EXPECT().Do(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
+	client := FastHttpRetryClient{Client: c}
+	client.WithRetryAttempts(2)
+
+	before := testutil.ToFloat64(retriesTotal)
+	assert.NoError(t, client.Do(&fasthttp.Request{}, &fasthttp.Response{}))
+	assert.Equal(t, before, testutil.ToFloat64(retriesTotal))
+}

--- a/router/api/handler.go
+++ b/router/api/handler.go
@@ -58,9 +58,20 @@ func (h *HttpHandler) AuthSetHandler(ctx *fasthttp.RequestCtx) {
 	if err := h.Login(ctx); err != nil {
 		response.ByErrorAndStatus(err, fasthttp.StatusBadGateway).Write(ctx)
 	}
+
+	recordAuthAttempt(authActionFromPath(ctx.Path()), authResultFromStatus(ctx.Response.StatusCode()))
 }
 
 func (h *HttpHandler) CaptchaVerifyHandler(ctx *fasthttp.RequestCtx) {
+	// passkey/init is routed straight here (no AuthSetHandler), so record its
+	// outcome from whatever response this handler leaves behind. The guard keeps
+	// the calls from AuthSetHandler for other actions from double-counting.
+	if isPasskeyInitPath(ctx.Path()) {
+		defer func() {
+			recordAuthAttempt(authActionPasskeyInit, authResultFromStatus(ctx.Response.StatusCode()))
+		}()
+	}
+
 	if ok, err := h.captcha.Verify(ctx); err != nil || !ok {
 		if err != nil {
 			response.NewCaptchaErrorResponse(err).Write(ctx)
@@ -88,6 +99,12 @@ func (h *HttpHandler) AuthResetHandler(ctx *fasthttp.RequestCtx) {
 			"error", err,
 		)
 	}
+
+	logoutResult := authResultSuccess
+	if err != nil {
+		logoutResult = authResultFailure
+	}
+	recordAuthAttempt(authActionLogout, logoutResult)
 
 	// The response is gateway-authored, so drop everything CopyFromResponse may have
 	// copied from the backend (Retry-After, X-Ratelimit-*, CORS, ...) rather than

--- a/router/api/metrics.go
+++ b/router/api/metrics.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	metricsNamespace  = "gateway"
+	metricsAuthSubsys = "auth"
+
+	authActionLogin       = "login"
+	authActionRegister    = "register"
+	authActionPasskey     = "passkey"
+	authActionPasskeyInit = "passkey_init"
+	authActionGoogle      = "google"
+	authActionLogout      = "logout"
+
+	authResultSuccess = "success"
+	authResultFailure = "failure"
+
+	passkeyInitPathSuffix = "/passkey/init"
+)
+
+// authAttemptsTotal counts edge auth outcomes the gateway can observe from the
+// response it produced (cookies set / backend status), bucketed by action.
+var authAttemptsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsAuthSubsys,
+	Name:      "attempts_total",
+	Help:      "Edge auth attempts by action (login, register, passkey, passkey_init, google, logout) and result.",
+}, []string{"action", "result"})
+
+func recordAuthAttempt(action, result string) {
+	authAttemptsTotal.WithLabelValues(action, result).Inc()
+}
+
+// authResultFromStatus maps the response status the handler ended up with to a
+// bounded success/failure label. A 2xx means the gateway completed the flow
+// (auth cookies written, or logout forwarded); anything else is a failure.
+func authResultFromStatus(status int) string {
+	if status >= fasthttp.StatusOK && status < fasthttp.StatusMultipleChoices {
+		return authResultSuccess
+	}
+
+	return authResultFailure
+}
+
+// authActionFromPath derives the action label from the request path. The auth-set
+// routes all share one handler, so the path is the only discriminator.
+func authActionFromPath(path []byte) string {
+	p := string(path)
+
+	switch {
+	case strings.HasSuffix(p, "/passkey"):
+		return authActionPasskey
+	case strings.HasSuffix(p, "/register"):
+		return authActionRegister
+	case strings.HasSuffix(p, "/provider/google"):
+		return authActionGoogle
+	default:
+		return authActionLogin
+	}
+}
+
+func isPasskeyInitPath(path []byte) bool {
+	return strings.HasSuffix(string(path), passkeyInitPathSuffix)
+}

--- a/router/api/metrics_test.go
+++ b/router/api/metrics_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/mocks"
+)
+
+func TestAuthActionFromPath(t *testing.T) {
+	cases := map[string]string{
+		"/api/auth/login":                authActionLogin,
+		"/api/auth/login/passkey":        authActionPasskey,
+		"/api/auth/register":             authActionRegister,
+		"/api/auth/provider/google":      authActionGoogle,
+		"/api/auth/something/unexpected": authActionLogin,
+	}
+
+	for path, want := range cases {
+		assert.Equal(t, want, authActionFromPath([]byte(path)), path)
+	}
+}
+
+func TestAuthResultFromStatus(t *testing.T) {
+	assert.Equal(t, authResultSuccess, authResultFromStatus(fasthttp.StatusOK))
+	assert.Equal(t, authResultSuccess, authResultFromStatus(fasthttp.StatusNoContent))
+	assert.Equal(t, authResultFailure, authResultFromStatus(fasthttp.StatusFound))
+	assert.Equal(t, authResultFailure, authResultFromStatus(fasthttp.StatusUnauthorized))
+	assert.Equal(t, authResultFailure, authResultFromStatus(fasthttp.StatusBadGateway))
+}
+
+func TestIsPasskeyInitPath(t *testing.T) {
+	assert.True(t, isPasskeyInitPath([]byte("/api/auth/login/passkey/init")))
+	assert.False(t, isPasskeyInitPath([]byte("/api/auth/login/passkey")))
+	assert.False(t, isPasskeyInitPath([]byte("/api/auth/login")))
+}
+
+// TestAuthSetHandlerRecordsAttemptMetric asserts a successful login advances the
+// counter for action=login result=success.
+func TestAuthSetHandlerRecordsAttemptMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	c.EXPECT().Verify(gomock.Any()).Return(true, nil)
+	s.EXPECT().ForwardRequest(gomock.Any(), nil).DoAndReturn(func(ctx *fasthttp.RequestCtx, _ []byte) error {
+		ctx.Response.SetStatusCode(fasthttp.StatusOK)
+		ctx.Response.SetBodyString(`{}`)
+		return nil
+	})
+
+	before := testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionLogin, authResultSuccess))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/auth/login")
+
+	h.AuthSetHandler(&ctx)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionLogin, authResultSuccess)))
+}
+
+// TestAuthSetHandlerRecordsFailureOnCaptcha asserts a captcha rejection records a failure.
+func TestAuthSetHandlerRecordsFailureOnCaptcha(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	c.EXPECT().Verify(gomock.Any()).Return(false, nil)
+
+	before := testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskey, authResultFailure))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/auth/login/passkey")
+
+	h.AuthSetHandler(&ctx)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskey, authResultFailure)))
+}
+
+// TestCaptchaVerifyHandlerRecordsPasskeyInit asserts the passkey/init route
+// records under action=passkey_init and nothing double-counts for other paths.
+func TestCaptchaVerifyHandlerRecordsPasskeyInit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	c.EXPECT().Verify(gomock.Any()).Return(true, nil)
+	s.EXPECT().ForwardRequest(gomock.Any(), nil).DoAndReturn(func(ctx *fasthttp.RequestCtx, _ []byte) error {
+		ctx.Response.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	before := testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskeyInit, authResultSuccess))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.SetRequestURI("/api/auth/login/passkey/init")
+
+	h.CaptchaVerifyHandler(&ctx)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskeyInit, authResultSuccess)))
+}
+
+// TestCaptchaVerifyHandlerNoMetricForNonInitPath asserts a bare CaptchaVerifyHandler
+// call on a non-init path does not touch the passkey_init counter.
+func TestCaptchaVerifyHandlerNoMetricForNonInitPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mocks.NewApiServiceMock(ctrl)
+	c := mocks.NewCaptchaProviderMock(ctrl)
+	h := NewHttp(config.Config{}, s, c, &mockCSRFSeeder{})
+
+	c.EXPECT().Verify(gomock.Any()).Return(false, fmt.Errorf("boom"))
+
+	before := testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskeyInit, authResultFailure))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.SetRequestURI("/api/auth/login/passkey")
+
+	h.CaptchaVerifyHandler(&ctx)
+
+	assert.Equal(t, before, testutil.ToFloat64(authAttemptsTotal.WithLabelValues(authActionPasskeyInit, authResultFailure)))
+}

--- a/service/api/forward.go
+++ b/service/api/forward.go
@@ -91,15 +91,22 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 		fasthttp.ReleaseResponse(resp)
 	}()
 
+	method := upstreamMethod(string(ctx.Method()))
+
 	start := time.Now()
-	err := s.doWithBreaker(req, resp)
+	err := withInFlight(upstreamRequestsInFlight, func() error {
+		return s.doWithBreaker(req, resp)
+	})
 	duration := time.Since(start)
 
 	if err != nil {
+		upstreamRequestsTotal.WithLabelValues(method, upstreamStatusError).Inc()
 		span.RecordError(err)
 
 		return fmt.Errorf("API request error: %w", err)
 	}
+
+	observeUpstream(method, resp.StatusCode(), duration.Seconds())
 
 	logger.DebugResponse(resp, ServiceId)
 	logger.FullForwarded(ctx, resp, ServiceId, duration)
@@ -112,13 +119,26 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 	}
 
 	// Coalesced: only the leader for this refresh token actually calls the API,
-	// concurrent callers share its result. CSRF is seeded inside the closure so it
-	// runs once per actual refresh, not once per waiter.
+	// concurrent callers share its result. CSRF seeding and the tokenRefreshTotal
+	// counter live inside the closure so they run once per actual refresh, not once
+	// per coalesced waiter. tokenRefreshDuration stays outside on purpose — it is
+	// per-waiter wall time, as its help text documents.
 	refreshKey := refresh.Key(auth.RefreshToken)
+	refreshStart := time.Now()
 	newAuth, err := s.refresh.Do(spanCtx, refreshKey, func(refreshCtx context.Context) (cookie.Auth, error) {
 		newAuth, err := s.refreshToken(auth, refreshCtx, ctx)
 		if err != nil {
+			// Transient failure: could not reach the API or it returned a non-401
+			// (e.g. 5xx). The session is preserved by the caller below.
+			tokenRefreshTotal.WithLabelValues(tokenRefreshSessionPreserved).Inc()
+
 			return newAuth, err
+		}
+
+		if newAuth.IsLogged() {
+			tokenRefreshTotal.WithLabelValues(tokenRefreshSuccess).Inc()
+		} else {
+			tokenRefreshTotal.WithLabelValues(tokenRefreshFailed).Inc()
 		}
 
 		if s.csrf != nil && newAuth.IsLogged() {
@@ -133,11 +153,11 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 
 		return newAuth, nil
 	})
+	tokenRefreshDuration.Observe(time.Since(refreshStart).Seconds())
 	if err != nil {
-		// Transient failure: could not reach the API or it returned a non-401
-		// (e.g. 5xx). The refresh token may still be valid, so DO NOT delete
-		// cookies / log the user out. Preserve the session and return a
-		// retryable status; the client can retry once the API recovers.
+		// Transient failure (see the closure): the refresh token may still be valid,
+		// so DO NOT delete cookies / log the user out. Preserve the session and
+		// return a retryable status; the client can retry once the API recovers.
 		span.RecordError(err)
 		slog.Warn("refresh token attempt failed, keeping session (transient)",
 			"trace_id", traces.FindTraceId(ctx),
@@ -173,14 +193,19 @@ func (s *HttpService) ForwardRequest(ctx *fasthttp.RequestCtx, body []byte) erro
 
 		// execute request 2nd attempt
 		retryStart := time.Now()
-		retryErr := s.doWithBreaker(req, resp)
+		retryErr := withInFlight(upstreamRequestsInFlight, func() error {
+			return s.doWithBreaker(req, resp)
+		})
 		retryDuration := time.Since(retryStart)
 
 		if retryErr != nil {
+			upstreamRequestsTotal.WithLabelValues(method, upstreamStatusError).Inc()
 			retrySpan.RecordError(retryErr)
 
 			return fmt.Errorf("API request with fresh token error: %w", retryErr)
 		}
+
+		observeUpstream(method, resp.StatusCode(), retryDuration.Seconds())
 
 		logger.DebugResponse(resp, ServiceId)
 		// Logged separately from the initial attempt above: this is a second, genuinely

--- a/service/api/forward_test.go
+++ b/service/api/forward_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/valyala/fasthttp"
 	"go.uber.org/mock/gomock"
@@ -1071,6 +1072,10 @@ func TestForwardRequestConcurrentRefreshesAreCoalesced(t *testing.T) {
 	errs := make([]error, n)
 	ctxs := make([]fasthttp.RequestCtx, n)
 
+	// tokenRefreshTotal is incremented inside the coalescing closure, so N coalesced
+	// waiters sharing one leader must advance it by exactly 1, not by N.
+	refreshMetricBefore := testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSuccess))
+
 	start := make(chan struct{})
 	for i := 0; i < n; i++ {
 		wg.Add(1)
@@ -1093,6 +1098,8 @@ func TestForwardRequestConcurrentRefreshesAreCoalesced(t *testing.T) {
 
 	assert.EqualValues(t, 1, atomic.LoadInt32(&client.refreshCalls), "exactly one refresh call across all coalesced requests")
 	assert.EqualValues(t, 2*n, atomic.LoadInt32(&client.proxyCalls), "each request still gets its own initial 401 + retried 200")
+	assert.Equal(t, refreshMetricBefore+1, testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSuccess)),
+		"token refresh counted once per actual refresh, not once per coalesced waiter")
 
 	for i := 0; i < n; i++ {
 		assert.NoError(t, errs[i])

--- a/service/api/metrics.go
+++ b/service/api/metrics.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	metricsUpstreamSubsys     = "upstream"
+	metricsTokenRefreshSubsys = "token_refresh"
+
+	// upstreamStatusError labels a forwarded call that failed before any HTTP
+	// response was received (transport error or open circuit breaker).
+	upstreamStatusError = "error"
+
+	// tokenRefreshSuccess: a fresh access token was obtained and the request retried.
+	tokenRefreshSuccess = "success"
+	// tokenRefreshFailed: the refresh token was genuinely rejected; the session is
+	// cleared and the user must log in again.
+	tokenRefreshFailed = "failed"
+	// tokenRefreshSessionPreserved: a transient API failure during refresh; cookies are
+	// kept and a 503 is returned so the client can retry.
+	tokenRefreshSessionPreserved = "session_preserved"
+)
+
+// upstreamRequestDuration measures only the forwarded round trip to the PHP API,
+// as distinct from the total gateway handler latency tracked by the http subsystem.
+var upstreamRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsUpstreamSubsys,
+	Name:      "request_duration_seconds",
+	Help:      "Duration of the forwarded request to the PHP API (upstream round trip time).",
+	Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+}, []string{"method"})
+
+// upstreamRequestsTotal counts forwarded requests to the PHP API by method and
+// response status class (2xx/3xx/4xx/5xx/other).
+var upstreamRequestsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsUpstreamSubsys,
+	Name:      "requests_total",
+	Help:      "Forwarded requests to the PHP API by method and response status class.",
+}, []string{"method", "status"})
+
+// upstreamRequestsInFlight tracks forwarded requests currently awaiting a PHP API response.
+var upstreamRequestsInFlight = promauto.NewGauge(prometheus.GaugeOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsUpstreamSubsys,
+	Name:      "requests_in_flight",
+	Help:      "Forwarded requests to the PHP API currently awaiting a response.",
+})
+
+// tokenRefreshTotal counts auto-refresh attempts on the forward path by outcome.
+var tokenRefreshTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsTokenRefreshSubsys,
+	Name:      "total",
+	Help:      "Automatic token-refresh attempts by outcome: success, failed, session_preserved.",
+}, []string{"result"})
+
+// tokenRefreshDuration measures the wall time of the coordinated refresh step
+// (includes any time a caller spent coalesced onto another caller's refresh).
+var tokenRefreshDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace: metricsNamespace,
+	Subsystem: metricsTokenRefreshSubsys,
+	Name:      "duration_seconds",
+	Help:      "Wall time of the coordinated token-refresh step on the forward path.",
+	Buckets:   []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+})
+
+// withInFlight runs fn while the in-flight gauge is incremented, guaranteeing the
+// matching decrement even if fn panics — mirrors client_golang's
+// InstrumentHandlerInFlight helper.
+func withInFlight(g prometheus.Gauge, fn func() error) error {
+	g.Inc()
+	defer g.Dec()
+
+	return fn()
+}
+
+// statusClass buckets an HTTP status code into a bounded label value.
+func statusClass(code int) string {
+	switch {
+	case code >= 200 && code < 300:
+		return "2xx"
+	case code >= 300 && code < 400:
+		return "3xx"
+	case code >= 400 && code < 500:
+		return "4xx"
+	case code >= 500 && code < 600:
+		return "5xx"
+	default:
+		return "other"
+	}
+}
+
+// observeUpstream records the duration and status class of one forwarded API call.
+func observeUpstream(method string, statusCode int, seconds float64) {
+	upstreamRequestDuration.WithLabelValues(method).Observe(seconds)
+	upstreamRequestsTotal.WithLabelValues(method, statusClass(statusCode)).Inc()
+}
+
+var knownUpstreamMethods = map[string]bool{
+	fasthttp.MethodGet:     true,
+	fasthttp.MethodHead:    true,
+	fasthttp.MethodPost:    true,
+	fasthttp.MethodPut:     true,
+	fasthttp.MethodPatch:   true,
+	fasthttp.MethodDelete:  true,
+	fasthttp.MethodOptions: true,
+}
+
+// upstreamMethod bounds the method label to a fixed set, mapping anything
+// unexpected to "other" so a malformed request can't inflate cardinality.
+func upstreamMethod(method string) string {
+	if knownUpstreamMethods[method] {
+		return method
+	}
+
+	return "other"
+}

--- a/service/api/metrics_test.go
+++ b/service/api/metrics_test.go
@@ -1,0 +1,226 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
+	"go.uber.org/mock/gomock"
+
+	"github.com/cash-track/gateway/config"
+	"github.com/cash-track/gateway/headers/cookie"
+	"github.com/cash-track/gateway/mocks"
+)
+
+func TestWithInFlightBalancesGaugeAndPropagatesResult(t *testing.T) {
+	before := testutil.ToFloat64(upstreamRequestsInFlight)
+
+	wantErr := fmt.Errorf("boom")
+	gotErr := withInFlight(upstreamRequestsInFlight, func() error {
+		// The gauge is incremented for the duration of fn.
+		assert.Equal(t, before+1, testutil.ToFloat64(upstreamRequestsInFlight))
+		return wantErr
+	})
+
+	assert.Equal(t, wantErr, gotErr)
+	assert.Equal(t, before, testutil.ToFloat64(upstreamRequestsInFlight))
+}
+
+func TestWithInFlightDecrementsOnPanic(t *testing.T) {
+	before := testutil.ToFloat64(upstreamRequestsInFlight)
+
+	assert.PanicsWithValue(t, "kaboom", func() {
+		_ = withInFlight(upstreamRequestsInFlight, func() error {
+			panic("kaboom")
+		})
+	})
+
+	assert.Equal(t, before, testutil.ToFloat64(upstreamRequestsInFlight))
+}
+
+func TestStatusClass(t *testing.T) {
+	cases := map[int]string{
+		200: "2xx",
+		204: "2xx",
+		301: "3xx",
+		404: "4xx",
+		503: "5xx",
+		100: "other",
+		600: "other",
+	}
+
+	for code, want := range cases {
+		assert.Equal(t, want, statusClass(code), "status %d", code)
+	}
+}
+
+func TestUpstreamMethod(t *testing.T) {
+	for _, m := range []string{
+		fasthttp.MethodGet, fasthttp.MethodHead, fasthttp.MethodPost, fasthttp.MethodPut,
+		fasthttp.MethodPatch, fasthttp.MethodDelete, fasthttp.MethodOptions,
+	} {
+		assert.Equal(t, m, upstreamMethod(m))
+	}
+
+	assert.Equal(t, "other", upstreamMethod("PROPFIND"))
+	assert.Equal(t, "other", upstreamMethod(""))
+}
+
+func TestObserveUpstreamRecordsDurationAndStatusClass(t *testing.T) {
+	before := testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodGet, "2xx"))
+	durBefore := testutil.CollectAndCount(upstreamRequestDuration)
+
+	observeUpstream(fasthttp.MethodGet, 200, 0.05)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodGet, "2xx")))
+	assert.GreaterOrEqual(t, testutil.CollectAndCount(upstreamRequestDuration), durBefore)
+}
+
+// TestForwardRequestRecordsUpstreamSuccessMetrics drives one plain forward and
+// asserts the upstream counter advanced for the observed status class.
+func TestForwardRequestRecordsUpstreamSuccessMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Any())
+	h.EXPECT().WithWriteTimeout(gomock.Any())
+	h.EXPECT().WithRetryAttempts(gomock.Any())
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	apiURL, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiURL}, nil, testBreaker(), testCoordinator())
+
+	before := testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodGet, "2xx"))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+
+	assert.NoError(t, s.ForwardRequest(&ctx, nil))
+	assert.Equal(t, before+1, testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodGet, "2xx")))
+}
+
+// TestForwardRequestRecordsUpstreamErrorMetric asserts the "error" status label
+// is used when the forwarded call fails before any response.
+func TestForwardRequestRecordsUpstreamErrorMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Any())
+	h.EXPECT().WithWriteTimeout(gomock.Any())
+	h.EXPECT().WithRetryAttempts(gomock.Any())
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).Return(fmt.Errorf("connection refused"))
+
+	apiURL, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiURL}, nil, testBreaker(), testCoordinator())
+
+	before := testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodPost, upstreamStatusError))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+
+	assert.Error(t, s.ForwardRequest(&ctx, nil))
+	assert.Equal(t, before+1, testutil.ToFloat64(upstreamRequestsTotal.WithLabelValues(fasthttp.MethodPost, upstreamStatusError)))
+}
+
+// TestForwardRequestRecordsTokenRefreshSuccess covers the success + retry path.
+func TestForwardRequestRecordsTokenRefreshSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Any())
+	h.EXPECT().WithWriteTimeout(gomock.Any())
+	h.EXPECT().WithRetryAttempts(gomock.Any())
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().DoTimeout(gomock.Any(), gomock.Any(), gomock.Eq(refreshHttpTimeout)).DoAndReturn(
+		func(_ *fasthttp.Request, resp *fasthttp.Response, _ time.Duration) error {
+			resp.SetStatusCode(fasthttp.StatusOK)
+			resp.SetBodyString(fmt.Sprintf(`{"accessToken":"a","refreshToken":"r","refreshTokenExpiredAt":"%s"}`, tomorrowRFC3339()))
+			return nil
+		})
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusOK)
+		return nil
+	})
+
+	apiURL, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiURL}, nil, testBreaker(), testCoordinator())
+
+	before := testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSuccess))
+	durBefore := testutil.CollectAndCount(tokenRefreshDuration)
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	assert.NoError(t, s.ForwardRequest(&ctx, nil))
+	assert.Equal(t, before+1, testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSuccess)))
+	assert.GreaterOrEqual(t, testutil.CollectAndCount(tokenRefreshDuration), durBefore)
+}
+
+// TestForwardRequestRecordsTokenRefreshFailed covers a genuinely expired refresh token.
+func TestForwardRequestRecordsTokenRefreshFailed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Any())
+	h.EXPECT().WithWriteTimeout(gomock.Any())
+	h.EXPECT().WithRetryAttempts(gomock.Any())
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().DoTimeout(gomock.Any(), gomock.Any(), gomock.Eq(refreshHttpTimeout)).DoAndReturn(
+		func(_ *fasthttp.Request, resp *fasthttp.Response, _ time.Duration) error {
+			resp.SetStatusCode(fasthttp.StatusUnauthorized)
+			return nil
+		})
+
+	apiURL, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiURL}, nil, testBreaker(), testCoordinator())
+
+	before := testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshFailed))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	assert.NoError(t, s.ForwardRequest(&ctx, nil))
+	assert.Equal(t, before+1, testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshFailed)))
+}
+
+// TestForwardRequestRecordsTokenRefreshSessionPreserved covers a transient API
+// failure during refresh: cookies kept, 503 returned.
+func TestForwardRequestRecordsTokenRefreshSessionPreserved(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	h := mocks.NewHttpRetryClientMock(ctrl)
+	h.EXPECT().WithReadTimeout(gomock.Any())
+	h.EXPECT().WithWriteTimeout(gomock.Any())
+	h.EXPECT().WithRetryAttempts(gomock.Any())
+	h.EXPECT().Do(gomock.Any(), gomock.Any()).DoAndReturn(func(_ *fasthttp.Request, resp *fasthttp.Response) error {
+		resp.SetStatusCode(fasthttp.StatusUnauthorized)
+		return nil
+	})
+	h.EXPECT().DoTimeout(gomock.Any(), gomock.Any(), gomock.Eq(refreshHttpTimeout)).Return(fmt.Errorf("api down"))
+
+	apiURL, _ := url.Parse(endpoint)
+	s := NewHttp(h, config.Config{ApiURI: apiURL}, nil, testBreaker(), testCoordinator())
+
+	before := testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSessionPreserved))
+
+	ctx := fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.SetCookie(cookie.AccessTokenCookieName, "access_token")
+	ctx.Request.Header.SetCookie(cookie.RefreshTokenCookieName, "refresh_token")
+
+	assert.NoError(t, s.ForwardRequest(&ctx, nil))
+	assert.Equal(t, fasthttp.StatusServiceUnavailable, ctx.Response.StatusCode())
+	assert.Equal(t, before+1, testutil.ToFloat64(tokenRefreshTotal.WithLabelValues(tokenRefreshSessionPreserved)))
+}


### PR DESCRIPTION
## Problem statement

The gateway exposed `:8081/metrics` but only with the default fasthttp request metrics. There was no visibility into the behaviour the gateway exists for: captcha verification, upstream forwarding latency and error rate, automatic token refresh, and per-action auth outcomes.

## Changes

Adds Prometheus metrics under the `gateway_` namespace on the existing `:8081/metrics` endpoint.

New series:

| Metric | Type | Labels |
|---|---|---|
| `gateway_captcha_verifications_total` | counter | `result` (solved/missed/error/disabled) |
| `gateway_captcha_score` | histogram | – |
| `gateway_upstream_request_duration_seconds` | histogram | `method` |
| `gateway_upstream_requests_total` | counter | `method`, `status` (class) |
| `gateway_upstream_requests_in_flight` | gauge | – |
| `gateway_token_refresh_total` | counter | `result` (success/failed/session_preserved) |
| `gateway_token_refresh_duration_seconds` | histogram | – |
| `gateway_auth_attempts_total` | counter | `action`, `result` |
| `gateway_upstream_retries_total` | counter | – |

Implementation notes:

- Each package owns its metrics in a `metrics.go` next to the code it measures, using `promauto` — idiomatic `client_golang`, no shared registry plumbing.
- `withInFlight` wraps both `doWithBreaker` call sites so the in-flight gauge is always decremented, including on panic.
- `token_refresh_total` is incremented inside the `singleflight` closure, so a burst of concurrent 401s that coalesce into one refresh counts exactly once.

## Verification

- Independent code review over the same multi-round pass as the sibling API change; no material findings on the gateway portion.
- `make test` (`go test -race`) passes with no data races. `golangci-lint run` clean. 100% statement coverage held on every touched logic package; new `_test.go` files cover the happy path and every failure branch. Added a concurrency test asserting exactly one `token_refresh_total{result="success"}` under 15 goroutines.
- Isolated build: 7 of the 9 metric families confirmed live on `/metrics`; the remaining 2 require a real upstream and are unit-covered.
- No OpenAPI facts changed — the metrics endpoint and its contract are unchanged.
